### PR TITLE
refactor: simplify future usage within the api clients

### DIFF
--- a/roborock/roborock_future.py
+++ b/roborock/roborock_future.py
@@ -14,12 +14,19 @@ class RoborockFuture:
         self.fut: Future = Future()
         self.loop = self.fut.get_loop()
 
-    def _resolve(self, item: tuple[Any, VacuumError | None]) -> None:
+    def _set_result(self, item: Any) -> None:
         if not self.fut.cancelled():
             self.fut.set_result(item)
 
-    def resolve(self, item: tuple[Any, VacuumError | None]) -> None:
-        self.loop.call_soon_threadsafe(self._resolve, item)
+    def set_result(self, item: Any) -> None:
+        self.loop.call_soon_threadsafe(self._set_result, item)
+
+    def _set_exception(self, exc: VacuumError) -> None:
+        if not self.fut.cancelled():
+            self.fut.set_exception(exc)
+
+    def set_exception(self, exc: VacuumError) -> None:
+        self.loop.call_soon_threadsafe(self._set_exception, exc)
 
     async def async_get(self, timeout: float | int) -> tuple[Any, VacuumError | None]:
         try:

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -378,20 +378,17 @@ class RoborockClientV1(RoborockClient):
                             if queue and queue.protocol == protocol:
                                 error = data_point_response.get("error")
                                 if error:
-                                    queue.resolve(
-                                        (
-                                            None,
-                                            VacuumError(
-                                                error.get("code"),
-                                                error.get("message"),
-                                            ),
-                                        )
+                                    queue.set_exception(
+                                        VacuumError(
+                                            error.get("code"),
+                                            error.get("message"),
+                                        ),
                                     )
                                 else:
                                     result = data_point_response.get("result")
                                     if isinstance(result, list) and len(result) == 1:
                                         result = result[0]
-                                    queue.resolve((result, None))
+                                    queue.set_result(result)
                             else:
                                 self._logger.debug("Received response for unknown request id %s", request_id)
                         else:
@@ -451,13 +448,13 @@ class RoborockClientV1(RoborockClient):
                         if queue:
                             if isinstance(decompressed, list):
                                 decompressed = decompressed[0]
-                            queue.resolve((decompressed, None))
+                            queue.set_result(decompressed)
                         else:
                             self._logger.debug("Received response for unknown request id %s", request_id)
                 else:
                     queue = self._waiting_queue.get(data.seq)
                     if queue:
-                        queue.resolve((data.payload, None))
+                        queue.set_result(data.payload)
                     else:
                         self._logger.debug("Received response for unknown request id %s", data.seq)
         except Exception as ex:

--- a/roborock/version_a01_apis/roborock_client_a01.py
+++ b/roborock/version_a01_apis/roborock_client_a01.py
@@ -135,7 +135,7 @@ class RoborockClientA01(RoborockClient):
                         converted_response = entries[data_point_protocol].post_process_fn(data_point)
                         queue = self._waiting_queue.get(int(data_point_number))
                         if queue and queue.protocol == protocol:
-                            queue.resolve((converted_response, None))
+                            queue.set_result(converted_response)
 
     async def update_values(
         self, dyad_data_protocols: list[RoborockDyadDataProtocol | RoborockZeoProtocol]

--- a/roborock/version_a01_apis/roborock_mqtt_client_a01.py
+++ b/roborock/version_a01_apis/roborock_mqtt_client_a01.py
@@ -43,7 +43,7 @@ class RoborockMqttClientA01(RoborockMqttClient, RoborockClientA01):
         futures = []
         if "10000" in payload["dps"]:
             for dps in json.loads(payload["dps"]["10000"]):
-                futures.append(asyncio.ensure_future(self._async_response(dps, response_protocol)))
+                futures.append(self._async_response(dps, response_protocol))
         self._send_msg_raw(m)
         responses = await asyncio.gather(*futures, return_exceptions=True)
         dps_responses: dict[int, typing.Any] = {}
@@ -54,7 +54,7 @@ class RoborockMqttClientA01(RoborockMqttClient, RoborockClientA01):
                     self._logger.warning("Timed out get req for %s after %s s", dps, self.queue_timeout)
                     dps_responses[dps] = None
                 else:
-                    dps_responses[dps] = response[0]
+                    dps_responses[dps] = response
         return dps_responses
 
     async def update_values(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,8 +51,7 @@ async def test_can_create_mqtt_roborock():
 async def test_sync_connect(mqtt_client):
     with patch("paho.mqtt.client.Client.connect", return_value=mqtt.MQTT_ERR_SUCCESS):
         with patch("paho.mqtt.client.Client.loop_start", return_value=mqtt.MQTT_ERR_SUCCESS):
-            connecting, connected_future = mqtt_client.sync_connect()
-            assert connecting is True
+            connected_future = mqtt_client.sync_connect()
             assert connected_future is not None
 
             connected_future.cancel()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from roborock.exceptions import VacuumError
 from roborock.roborock_future import RoborockFuture
 
 
@@ -10,10 +11,18 @@ def test_can_create():
 
 
 @pytest.mark.asyncio
-async def test_put():
+async def test_set_result():
     rq = RoborockFuture(1)
-    rq.resolve(("test", None))
-    assert await rq.async_get(1) == ("test", None)
+    rq.set_result("test")
+    assert await rq.async_get(1) == "test"
+
+
+@pytest.mark.asyncio
+async def test_set_exception():
+    rq = RoborockFuture(1)
+    rq.set_exception(VacuumError("test"))
+    with pytest.raises(VacuumError):
+        assert await rq.async_get(1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Simplify future usage within the api clients by separating how message results and exceptions are passed, using built in exception handling in futures. This raises exceptions instead of returning exceptions. This is a step of simplification on the path to fixing some concurrency issues in the client libraries.

Issue #228