### PR TITLE
chore: client library inheritance fixes and simplifications

### DIFF
--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -4,6 +4,7 @@ import json
 import math
 import struct
 import time
+from abc import ABC
 from collections.abc import Callable, Coroutine
 from typing import Any, TypeVar, final
 
@@ -142,19 +143,22 @@ class ListenerModel:
     cache: dict[CacheableAttribute, AttributeCache]
 
 
-class RoborockClientV1(RoborockClient):
+class RoborockClientV1(RoborockClient, ABC):
+    """Roborock client base class for version 1 devices."""
+
     _listeners: dict[str, ListenerModel] = {}
 
-    def __init__(self, device_info: DeviceData, logger, endpoint: str):
-        super().__init__(endpoint, device_info)
+    def __init__(self, device_info: DeviceData, endpoint: str):
+        """Initializes the Roborock client."""
+        super().__init__(device_info)
         self._status_type: type[Status] = ModelStatus.get(device_info.model, S7MaxVStatus)
-        self._logger = logger
         self.cache: dict[CacheableAttribute, AttributeCache] = {
             cacheable_attribute: AttributeCache(attr, self) for cacheable_attribute, attr in get_cache_map().items()
         }
         if device_info.device.duid not in self._listeners:
             self._listeners[device_info.device.duid] = ListenerModel({}, self.cache)
         self.listener_model = self._listeners[device_info.device.duid]
+        self._endpoint = endpoint
 
     def release(self):
         super().release()

--- a/roborock/version_1_apis/roborock_local_client_v1.py
+++ b/roborock/version_1_apis/roborock_local_client_v1.py
@@ -1,16 +1,25 @@
+import logging
+
 from roborock.local_api import RoborockLocalClient
 
 from .. import CommandVacuumError, DeviceData, RoborockCommand, RoborockException
 from ..exceptions import VacuumError
 from ..protocol import MessageParser
 from ..roborock_message import MessageRetry, RoborockMessage, RoborockMessageProtocol
+from ..util import RoborockLoggerAdapter
 from .roborock_client_v1 import COMMANDS_SECURED, RoborockClientV1
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class RoborockLocalClientV1(RoborockLocalClient, RoborockClientV1):
+    """Roborock local client for v1 devices."""
+
     def __init__(self, device_data: DeviceData, queue_timeout: int = 4):
+        """Initialize the Roborock local client."""
         RoborockLocalClient.__init__(self, device_data, queue_timeout)
-        RoborockClientV1.__init__(self, device_data, self._logger, "abc")
+        RoborockClientV1.__init__(self, device_data, "abc")
+        self._logger = RoborockLoggerAdapter(device_data.device.name, _LOGGER)
 
     def build_roborock_message(
         self, method: RoborockCommand | str, params: list | dict | int | None = None

--- a/roborock/version_a01_apis/roborock_client_a01.py
+++ b/roborock/version_a01_apis/roborock_client_a01.py
@@ -1,6 +1,8 @@
 import dataclasses
 import json
+import logging
 import typing
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from datetime import time
 
@@ -37,6 +39,8 @@ from roborock.roborock_message import (
     RoborockMessageProtocol,
     RoborockZeoProtocol,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -101,9 +105,12 @@ zeo_data_protocol_entries = {
 }
 
 
-class RoborockClientA01(RoborockClient):
-    def __init__(self, endpoint: str, device_info: DeviceData, category: RoborockCategory, queue_timeout: int = 4):
-        super().__init__(endpoint, device_info, queue_timeout)
+class RoborockClientA01(RoborockClient, ABC):
+    """Roborock client base class for A01 devices."""
+
+    def __init__(self, device_info: DeviceData, category: RoborockCategory, queue_timeout: int = 4):
+        """Initialize the Roborock client."""
+        super().__init__(device_info, queue_timeout)
         self.category = category
 
     def on_message_received(self, messages: list[RoborockMessage]) -> None:
@@ -137,8 +144,8 @@ class RoborockClientA01(RoborockClient):
                         if queue and queue.protocol == protocol:
                             queue.set_result(converted_response)
 
+    @abstractmethod
     async def update_values(
         self, dyad_data_protocols: list[RoborockDyadDataProtocol | RoborockZeoProtocol]
     ) -> dict[RoborockDyadDataProtocol | RoborockZeoProtocol, typing.Any]:
         """This should handle updating for each given protocol."""
-        raise NotImplementedError

--- a/roborock/version_a01_apis/roborock_mqtt_client_a01.py
+++ b/roborock/version_a01_apis/roborock_mqtt_client_a01.py
@@ -1,6 +1,6 @@
 import asyncio
-import base64
 import json
+import logging
 import typing
 
 from Crypto.Cipher import AES
@@ -9,7 +9,7 @@ from Crypto.Util.Padding import pad, unpad
 from roborock.cloud_api import RoborockMqttClient
 from roborock.containers import DeviceData, RoborockCategory, UserData
 from roborock.exceptions import RoborockException
-from roborock.protocol import MessageParser, Utils
+from roborock.protocol import MessageParser
 from roborock.roborock_message import (
     RoborockDyadDataProtocol,
     RoborockMessage,
@@ -17,20 +17,26 @@ from roborock.roborock_message import (
     RoborockZeoProtocol,
 )
 
+from ..util import RoborockLoggerAdapter
 from .roborock_client_a01 import RoborockClientA01
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class RoborockMqttClientA01(RoborockMqttClient, RoborockClientA01):
+    """Roborock mqtt client for A01 devices."""
+
     def __init__(
         self, user_data: UserData, device_info: DeviceData, category: RoborockCategory, queue_timeout: int = 10
     ) -> None:
+        """Initialize the Roborock mqtt client."""
         rriot = user_data.rriot
         if rriot is None:
             raise RoborockException("Got no rriot data from user_data")
-        endpoint = base64.b64encode(Utils.md5(rriot.k.encode())[8:14]).decode()
 
         RoborockMqttClient.__init__(self, user_data, device_info, queue_timeout)
-        RoborockClientA01.__init__(self, endpoint, device_info, category, queue_timeout)
+        RoborockClientA01.__init__(self, device_info, category, queue_timeout)
+        self._logger = RoborockLoggerAdapter(device_info.device.name, _LOGGER)
 
     async def send_message(self, roborock_message: RoborockMessage):
         await self.validate_connection()


### PR DESCRIPTION
Update the base classes to use the `abc` package, which provides the infrastructure for defining abstract base classes. Remove variables that are overridden in multiple places so that variables are only set once in the class hierarchy. The fixes include:
- Use `@abstractmethod` to avoid needing the `raise NotImplemented` reducing untested lines of code
- Set `_endpoint` only once, rather than multiple times. Removed the places where it is not used. (Question: Local commands use it when secured with "abc" but does it do anything?)
- Set `_logger` once for each client in the client itself so that the log messages are associated with the actual client being used. This will let us tell the difference between a local client disconnecting and a cloud client disconnecting which is difficult to do today
- Remove duplicate definition of `_send_msg_raw` in both the v1 mqtt client and the base mqtt client

Issue #228