### PR TITLE
fix: bump commitlint and allow caps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5.4.5
+      - uses: wagoid/commitlint-github-action@v6.2.0
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-    extends: ["@commitlint/config-conventional"],
-    ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
-};

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     extends: ["@commitlint/config-conventional"],
     ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
     rules: {

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,9 @@
+module.exports = {
+    extends: ["@commitlint/config-conventional"],
+    ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+    rules: {
+        // Disable the rule that enforces lowercase in subject
+        "subject-case": [0], // 0 = disable, 1 = warn, 2 = error
+    },
+
+};


### PR DESCRIPTION
This should allow caps and get us past the commitlint breaking change.

Doing this as a fix to alos check and see if semantic release is working on this new repo