### PR TITLE
chore: add local api test coverage

### DIFF
--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -347,3 +347,4 @@ BASE_URL_REQUEST = {
 GET_CODE_RESPONSE = {"code": 200, "msg": "success", "data": None}
 HASHED_USER = hashlib.md5((USER_ID + ":" + K_VALUE).encode()).hexdigest()[2:10]
 MQTT_PUBLISH_TOPIC = f"rr/m/o/{USER_ID}/{HASHED_USER}/{PRODUCT_ID}"
+TEST_LOCAL_API_HOST = "1.1.1.1"

--- a/tests/test_local_api_v1.py
+++ b/tests/test_local_api_v1.py
@@ -1,0 +1,37 @@
+"""Tests for the Roborock Local Client V1."""
+
+from queue import Queue
+
+from roborock.protocol import MessageParser
+from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
+from roborock.version_1_apis import RoborockLocalClientV1
+
+from .mock_data import LOCAL_KEY
+
+
+def build_rpc_response(protocol: RoborockMessageProtocol, seq: int) -> bytes:
+    """Build an encoded RPC response message."""
+    message = RoborockMessage(
+        protocol=protocol,
+        random=23,
+        seq=seq,
+        payload=b"ignored",
+    )
+    return MessageParser.build(message, local_key=LOCAL_KEY)
+
+
+async def test_async_connect(
+    local_client: RoborockLocalClientV1,
+    received_requests: Queue,
+    response_queue: Queue,
+):
+    """Test that we can connect to the Roborock device."""
+    response_queue.put(build_rpc_response(RoborockMessageProtocol.HELLO_RESPONSE, 1))
+    response_queue.put(build_rpc_response(RoborockMessageProtocol.PING_RESPONSE, 2))
+
+    await local_client.async_connect()
+    assert local_client.is_connected()
+    assert received_requests.qsize() == 2
+
+    await local_client.async_disconnect()
+    assert not local_client.is_connected()


### PR DESCRIPTION
Add local API coverage using a fake local transport. This reuses the request/response queue from the MQTT test and mocks out the transport similar to the sockets.

Issue #228