### PR TITLE
chore: update CI to run on one platform, but multiple python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,9 @@ jobs:
       matrix:
         python-version:
           - "3.11"
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macOS-latest
-    runs-on: ${{ matrix.os }}
+          - "3.12"
+          - "3.13"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
This will run the library on python 3.11, 3.12, 3.13 but drop windows and mac platforms. The motivation is that incompatibility issues seem more likely to happen from new python versions rather than different platforms. This matches most other project norms i've seen.