### PR TITLE
fix: threadsafe waiting queue

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -17,7 +17,7 @@ from .exceptions import (
     RoborockTimeout,
     UnknownMethodError,
 )
-from .roborock_future import RoborockFuture
+from .roborock_future import RequestKey, RoborockFuture, WaitingQueue
 from .roborock_message import (
     RoborockMessage,
     RoborockMessageProtocol,
@@ -38,7 +38,7 @@ class RoborockClient(ABC):
         """Initialize RoborockClient."""
         self.device_info = device_info
         self._nonce = secrets.token_bytes(16)
-        self._waiting_queue: dict[int, RoborockFuture] = {}
+        self._waiting_queue = WaitingQueue()
         self._last_device_msg_in = time.monotonic()
         self._last_disconnection = time.monotonic()
         self.keep_alive = KEEPALIVE
@@ -89,33 +89,22 @@ class RoborockClient(ABC):
             await self.async_disconnect()
         await self.async_connect()
 
-    async def _wait_response(self, request_id: int, queue: RoborockFuture) -> Any:
+    async def _wait_response(self, request_key: RequestKey, future: RoborockFuture) -> Any:
         try:
-            response = await queue.async_get(self.queue_timeout)
+            response = await future.async_get(self.queue_timeout)
             if response == "unknown_method":
                 raise UnknownMethodError("Unknown method")
             return response
         except (asyncio.TimeoutError, asyncio.CancelledError):
-            raise RoborockTimeout(f"id={request_id} Timeout after {self.queue_timeout} seconds") from None
+            raise RoborockTimeout(f"id={request_key} Timeout after {self.queue_timeout} seconds") from None
         finally:
-            self._waiting_queue.pop(request_id, None)
+            self._waiting_queue.safe_pop(request_key)
 
-    def _async_response(self, request_id: int, protocol_id: int = 0) -> Any:
-        queue = RoborockFuture(protocol_id)
-        if request_id in self._waiting_queue and not (
-            request_id == 2 and protocol_id == RoborockMessageProtocol.PING_REQUEST
-        ):
-            new_id = get_next_int(10000, 32767)
-            self._logger.warning(
-                "Attempting to create a future with an existing id %s (%s)... New id is %s. "
-                "Code may not function properly.",
-                request_id,
-                protocol_id,
-                new_id,
-            )
-            request_id = new_id
-        self._waiting_queue[request_id] = queue
-        return asyncio.ensure_future(self._wait_response(request_id, queue))
+
+    def _async_response(self, request_key: RequestKey) -> Any:
+        future = RoborockFuture()
+        self._waiting_queue.put(request_key, future)
+        return asyncio.ensure_future(self._wait_response(request_key, future))
 
     @abstractmethod
     async def send_message(self, roborock_message: RoborockMessage):

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -14,7 +14,7 @@ from .api import KEEPALIVE, RoborockClient
 from .containers import DeviceData, UserData
 from .exceptions import RoborockException, VacuumError
 from .protocol import MessageParser, md5hex
-from .roborock_future import RoborockFuture
+from .roborock_future import RequestKey
 
 _LOGGER = logging.getLogger(__name__)
 CONNECT_REQUEST_ID = 0
@@ -72,12 +72,11 @@ class RoborockMqttClient(RoborockClient, ABC):
         self._mqtt_password = rriot.s
         self._hashed_password = md5hex(self._mqtt_password + ":" + rriot.k)[16:]
         self._mqtt_client.username_pw_set(self._hashed_user, self._hashed_password)
-        self._waiting_queue: dict[int, RoborockFuture] = {}
         self._mutex = Lock()
 
     def _mqtt_on_connect(self, *args, **kwargs):
         _, __, ___, rc, ____ = args
-        connection_queue = self._waiting_queue.get(CONNECT_REQUEST_ID)
+        connection_queue = self._waiting_queue.safe_pop(RequestKey(CONNECT_REQUEST_ID))
         if rc != mqtt.MQTT_ERR_SUCCESS:
             message = f"Failed to connect ({mqtt.error_string(rc)})"
             self._logger.error(message)
@@ -98,6 +97,8 @@ class RoborockMqttClient(RoborockClient, ABC):
         self._logger.info(f"Subscribed to topic {topic}")
         if connection_queue:
             connection_queue.set_result(True)
+        else:
+            self._logger.debug("Connected but no connect future")
 
     def _mqtt_on_message(self, *args, **kwargs):
         client, __, msg = args
@@ -112,9 +113,11 @@ class RoborockMqttClient(RoborockClient, ABC):
         try:
             exc = RoborockException(mqtt.error_string(rc)) if rc != mqtt.MQTT_ERR_SUCCESS else None
             super().on_connection_lost(exc)
-            connection_queue = self._waiting_queue.get(DISCONNECT_REQUEST_ID)
+            connection_queue = self._waiting_queue.safe_pop(RequestKey(DISCONNECT_REQUEST_ID))
             if connection_queue:
                 connection_queue.set_result(True)
+            else:
+                self._logger.debug("Disconnected but no disconnect future")
         except Exception as ex:
             self._logger.exception(ex)
 
@@ -124,10 +127,11 @@ class RoborockMqttClient(RoborockClient, ABC):
 
     def _sync_disconnect(self) -> Any:
         if not self.is_connected():
+            self._logger.debug("Already disconnected from mqtt")
             return None
 
         self._logger.info("Disconnecting from mqtt")
-        disconnected_future = self._async_response(DISCONNECT_REQUEST_ID)
+        disconnected_future = self._async_response(RequestKey(DISCONNECT_REQUEST_ID))
         rc = self._mqtt_client.disconnect()
 
         if rc == mqtt.MQTT_ERR_NO_CONN:
@@ -149,7 +153,7 @@ class RoborockMqttClient(RoborockClient, ABC):
             raise RoborockException("Mqtt information was not entered. Cannot connect.")
 
         self._logger.debug("Connecting to mqtt")
-        connected_future = self._async_response(CONNECT_REQUEST_ID)
+        connected_future = self._async_response(RequestKey(CONNECT_REQUEST_ID))
         self._mqtt_client.connect(host=self._mqtt_host, port=self._mqtt_port, keepalive=KEEPALIVE)
         self._mqtt_client.maybe_restart_loop()
         return connected_future

--- a/roborock/roborock_future.py
+++ b/roborock/roborock_future.py
@@ -1,16 +1,64 @@
 from __future__ import annotations
 
+import logging
 from asyncio import Future
+from dataclasses import dataclass
+from threading import Lock
 from typing import Any
 
 import async_timeout
 
-from .exceptions import VacuumError
+from .exceptions import UnknownMethodError, VacuumError
+from .roborock_message import RoborockMessageProtocol
+
+_LOGGER = logging.getLogger(__name__)
+_TRIES = 3
+
+
+@dataclass(frozen=True)
+class RequestKey:
+    """A key for a Roborock message request."""
+
+    request_id: int
+    protocol: RoborockMessageProtocol | int = 0
+
+    def __str__(self) -> str:
+        """Get the key for the request."""
+        return f"{self.request_id}-{self.protocol}"
+
+
+class WaitingQueue:
+    """A threadsafe waiting queue for Roborock messages."""
+
+    def __init__(self) -> None:
+        """Initialize the waiting queue."""
+        self._lock = Lock()
+        self._queue: dict[RequestKey, RoborockFuture] = {}
+
+    def put(self, request_key: RequestKey, future: RoborockFuture) -> None:
+        """Create a future for the given protocol."""
+        _LOGGER.debug("Putting request key %s in the queue", request_key)
+        with self._lock:
+            if request_key in self._queue:
+                raise ValueError(f"Request key {request_key} already exists in the queue")
+            self._queue[request_key] = future
+
+    def safe_pop(self, request_key: RequestKey) -> RoborockFuture | None:
+        """Get the future from the queue if it has not yet been popped, otherwise ignore."""
+        _LOGGER.debug("Popping request key %s from the queue", request_key)
+        with self._lock:
+            return self._queue.pop(request_key, None)
 
 
 class RoborockFuture:
-    def __init__(self, protocol: int):
-        self.protocol = protocol
+    """A threadsafe asyncio Future for Roborock messages.
+
+    The results may be set from a background thread. The future
+    must be awaited in an asyncio event loop.
+    """
+
+    def __init__(self):
+        """Initialize the Roborock future."""
         self.fut: Future = Future()
         self.loop = self.fut.get_loop()
 
@@ -28,9 +76,15 @@ class RoborockFuture:
     def set_exception(self, exc: VacuumError) -> None:
         self.loop.call_soon_threadsafe(self._set_exception, exc)
 
-    async def async_get(self, timeout: float | int) -> tuple[Any, VacuumError | None]:
+    async def async_get(self, timeout: float | int) -> Any:
+        """Get the result from the future or raises an error."""
         try:
             async with async_timeout.timeout(timeout):
-                return await self.fut
+                response = await self.fut
+                # This should be moved to the specific client that handles this
+                # and set an exception directly rather than patching an exception here
+                if response == "unknown_method":
+                    raise UnknownMethodError("Unknown method")
+                return response
         finally:
             self.fut.cancel()

--- a/roborock/roborock_future.py
+++ b/roborock/roborock_future.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import async_timeout
 
-from .exceptions import UnknownMethodError, VacuumError
+from .exceptions import VacuumError
 from .roborock_message import RoborockMessageProtocol
 
 _LOGGER = logging.getLogger(__name__)

--- a/roborock/roborock_future.py
+++ b/roborock/roborock_future.py
@@ -80,11 +80,6 @@ class RoborockFuture:
         """Get the result from the future or raises an error."""
         try:
             async with async_timeout.timeout(timeout):
-                response = await self.fut
-                # This should be moved to the specific client that handles this
-                # and set an exception directly rather than patching an exception here
-                if response == "unknown_method":
-                    raise UnknownMethodError("Unknown method")
-                return response
+                return await self.fut
         finally:
             self.fut.cancel()

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -47,6 +47,7 @@ from roborock.containers import (
     WashTowelMode,
 )
 from roborock.protocol import Utils
+from roborock.roborock_future import RequestKey
 from roborock.roborock_message import (
     ROBOROCK_DATA_CONSUMABLE_PROTOCOL,
     ROBOROCK_DATA_STATUS_PROTOCOL,
@@ -391,8 +392,9 @@ class RoborockClientV1(RoborockClient, ABC):
                         if data_point_number == "102":
                             data_point_response = json.loads(data_point)
                             request_id = data_point_response.get("id")
-                            queue = self._waiting_queue.get(request_id)
-                            if queue and queue.protocol == protocol:
+                            request_key = RequestKey(request_id, protocol)
+                            queue = self._waiting_queue.safe_pop(request_key)
+                            if queue:
                                 error = data_point_response.get("error")
                                 if error:
                                     queue.set_exception(
@@ -407,7 +409,7 @@ class RoborockClientV1(RoborockClient, ABC):
                                         result = result[0]
                                     queue.set_result(result)
                             else:
-                                self._logger.debug("Received response for unknown request id %s", request_id)
+                                self._logger.debug("Received response for unknown request id %s", request_key)
                         else:
                             try:
                                 data_protocol = RoborockDataProtocol(int(data_point_number))
@@ -467,19 +469,21 @@ class RoborockClientV1(RoborockClient, ABC):
                         except ValueError as err:
                             raise RoborockException(f"Failed to decode {data.payload!r} for {data.protocol}") from err
                         decompressed = Utils.decompress(decrypted)
-                        queue = self._waiting_queue.get(request_id)
+                        request_key = RequestKey(request_id, protocol)
+                        queue = self._waiting_queue.safe_pop(request_key)
                         if queue:
                             if isinstance(decompressed, list):
                                 decompressed = decompressed[0]
                             queue.set_result(decompressed)
                         else:
-                            self._logger.debug("Received response for unknown request id %s", request_id)
+                            self._logger.debug("Received response for unknown request id %s", request_key)
                 else:
-                    queue = self._waiting_queue.get(data.seq)
+                    request_key = RequestKey(data.seq, protocol)
+                    queue = self._waiting_queue.safe_pop(request_key)
                     if queue:
                         queue.set_result(data.payload)
                     else:
-                        self._logger.debug("Received response for unknown request id %s", data.seq)
+                        self._logger.debug("Received response for unknown request id %s", request_key)
         except Exception as ex:
             self._logger.exception(ex)
 

--- a/roborock/version_a01_apis/roborock_client_a01.py
+++ b/roborock/version_a01_apis/roborock_client_a01.py
@@ -144,11 +144,8 @@ class RoborockClientA01(RoborockClient, ABC):
                         # Auto convert into data struct we want.
                         converted_response = entries[data_point_protocol].post_process_fn(data_point)
                         request_key = RequestKey(int(data_point_number), protocol)
-                        future = self._waiting_queue.safe_pop(request_key)
-                        if future is not None:
+                        if future := self._waiting_queue.safe_pop(request_key, "a01"):
                             future.set_result(converted_response)
-                        else:
-                            self._logger.debug(f"Got response for {request_key} but no future found")
 
     @abstractmethod
     async def update_values(

--- a/roborock/version_a01_apis/roborock_mqtt_client_a01.py
+++ b/roborock/version_a01_apis/roborock_mqtt_client_a01.py
@@ -10,6 +10,7 @@ from roborock.cloud_api import RoborockMqttClient
 from roborock.containers import DeviceData, RoborockCategory, UserData
 from roborock.exceptions import RoborockException
 from roborock.protocol import MessageParser
+from roborock.roborock_future import RequestKey
 from roborock.roborock_message import (
     RoborockDyadDataProtocol,
     RoborockMessage,
@@ -50,7 +51,7 @@ class RoborockMqttClientA01(RoborockMqttClient, RoborockClientA01):
         futures = []
         if "10000" in payload["dps"]:
             for dps in json.loads(payload["dps"]["10000"]):
-                futures.append(self._async_response(dps, response_protocol))
+                futures.append(self._async_response(RequestKey(dps, response_protocol)))
         self._send_msg_raw(m)
         responses = await asyncio.gather(*futures, return_exceptions=True)
         dps_responses: dict[int, typing.Any] = {}

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,32 +1,123 @@
 import asyncio
+import logging
 
 import pytest
 
 from roborock.exceptions import VacuumError
-from roborock.roborock_future import RoborockFuture
+from roborock.roborock_future import RequestKey, RoborockFuture, WaitingQueue
+from roborock.roborock_message import RoborockMessageProtocol
+
+_LOGGER = logging.getLogger(__name__)
+TIMEOUT = 5
 
 
-def test_can_create():
-    RoborockFuture(1)
+async def test_can_create() -> None:
+    RoborockFuture()
 
 
-@pytest.mark.asyncio
-async def test_set_result():
-    rq = RoborockFuture(1)
+async def test_set_result() -> None:
+    rq = RoborockFuture()
     rq.set_result("test")
     assert await rq.async_get(1) == "test"
 
 
-@pytest.mark.asyncio
-async def test_set_exception():
-    rq = RoborockFuture(1)
+async def test_set_exception() -> None:
+    rq = RoborockFuture()
     rq.set_exception(VacuumError("test"))
     with pytest.raises(VacuumError):
         assert await rq.async_get(1)
 
 
-@pytest.mark.asyncio
-async def test_get_timeout():
-    rq = RoborockFuture(1)
+async def test_get_timeout() -> None:
+    rq = RoborockFuture()
     with pytest.raises(asyncio.TimeoutError):
         await rq.async_get(0.01)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        RequestKey(1),
+        RequestKey(1, RoborockMessageProtocol.RPC_RESPONSE),
+    ],
+)
+async def test_queue_result_in_thread(key: RequestKey) -> None:
+    queue = WaitingQueue()
+
+    future = RoborockFuture()
+    queue.put(key, future)
+
+    def set_result_in_thread():
+        fut = queue.safe_pop(key)
+        assert fut is not None
+        fut.set_result("value1")
+
+    loop = asyncio.get_event_loop()
+    task = loop.run_in_executor(None, set_result_in_thread)
+    await task
+
+    assert await future.async_get(TIMEOUT) == "value1"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        RequestKey(1),
+        RequestKey(1, RoborockMessageProtocol.RPC_RESPONSE),
+    ],
+)
+async def test_queue_set_exception_in_thread(key: RequestKey) -> None:
+    queue = WaitingQueue()
+
+    future = RoborockFuture()
+    queue.put(key, future)
+
+    def set_result_in_thread():
+        fut = queue.safe_pop(key)
+        assert fut is not None
+        fut.set_exception(VacuumError("value1"))
+
+    loop = asyncio.get_event_loop()
+    task = loop.run_in_executor(None, set_result_in_thread)
+    await task
+
+    with pytest.raises(VacuumError, match="value1"):
+        await future.async_get(TIMEOUT)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        RequestKey(1),
+        RequestKey(1, RoborockMessageProtocol.RPC_RESPONSE),
+    ],
+)
+async def test_queue_item_not_found(key: RequestKey) -> None:
+    queue = WaitingQueue()
+    assert queue.safe_pop(key) is None
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        RequestKey(1),
+        RequestKey(1, RoborockMessageProtocol.RPC_RESPONSE),
+    ],
+)
+async def test_queue_duplicate_item_fails(key: RequestKey) -> None:
+    queue = WaitingQueue()
+    future1 = RoborockFuture()
+    queue.put(key, future1)
+
+    future2 = RoborockFuture()
+    with pytest.raises(ValueError):
+        queue.put(key, future2)
+
+
+async def test_unique_protocol() -> None:
+    queue = WaitingQueue()
+    future1 = RoborockFuture()
+    queue.put(RequestKey(1, RoborockMessageProtocol.RPC_RESPONSE), future1)
+
+    future2 = RoborockFuture()
+    queue.put(RequestKey(1, RoborockMessageProtocol.GENERAL_RESPONSE), future2)


### PR DESCRIPTION
Make the waiting queue a threadsafe queue. 

This attempts to push the protocol to be a request key, but it seems to have odd interactions with local clients that munge the protocol. Will do some testing on a live system before marking ready for review. Parts of this may end up getting reverted.

Issue #228