### PR TITLE
fix: fix queue timeout variable and set default in tests of 10 seconds

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -31,8 +31,9 @@ class RoborockClient(ABC):
     """Roborock client base class."""
 
     _logger: logging.LoggerAdapter
+    queue_timeout: int
 
-    def __init__(self, device_info: DeviceData, queue_timeout: int = 4) -> None:
+    def __init__(self, device_info: DeviceData) -> None:
         """Initialize RoborockClient."""
         self.event_loop = get_running_loop_or_create_one()
         self.device_info = device_info
@@ -45,7 +46,6 @@ class RoborockClient(ABC):
             "misc_info": {"Nonce": base64.b64encode(self._nonce).decode("utf-8")}
         }
         self.is_available: bool = True
-        self.queue_timeout = queue_timeout
 
     def __del__(self) -> None:
         self.release()

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -46,12 +46,12 @@ class _Mqtt(mqtt.Client):
 class RoborockMqttClient(RoborockClient, ABC):
     """Roborock MQTT client base class."""
 
-    def __init__(self, user_data: UserData, device_info: DeviceData, queue_timeout: int = 10) -> None:
+    def __init__(self, user_data: UserData, device_info: DeviceData) -> None:
         """Initialize the Roborock MQTT client."""
         rriot = user_data.rriot
         if rriot is None:
             raise RoborockException("Got no rriot data from user_data")
-        RoborockClient.__init__(self, device_info, queue_timeout)
+        RoborockClient.__init__(self, device_info)
         self._mqtt_user = rriot.u
         self._hashed_user = md5hex(self._mqtt_user + ":" + rriot.k)[2:10]
         url = urlparse(rriot.r.m)

--- a/roborock/local_api.py
+++ b/roborock/local_api.py
@@ -37,7 +37,7 @@ class _LocalProtocol(asyncio.Protocol):
 class RoborockLocalClient(RoborockClient, ABC):
     """Roborock local client base class."""
 
-    def __init__(self, device_data: DeviceData, queue_timeout: int = 4):
+    def __init__(self, device_data: DeviceData):
         """Initialize the Roborock local client."""
         if device_data.host is None:
             raise RoborockException("Host is required")
@@ -48,7 +48,7 @@ class RoborockLocalClient(RoborockClient, ABC):
         self.transport: Transport | None = None
         self._mutex = Lock()
         self.keep_alive_task: TimerHandle | None = None
-        RoborockClient.__init__(self, device_data, queue_timeout)
+        RoborockClient.__init__(self, device_data)
         self._local_protocol = _LocalProtocol(self._data_received, self._connection_lost)
 
     def _data_received(self, message):

--- a/roborock/version_1_apis/roborock_local_client_v1.py
+++ b/roborock/version_1_apis/roborock_local_client_v1.py
@@ -17,8 +17,9 @@ class RoborockLocalClientV1(RoborockLocalClient, RoborockClientV1):
 
     def __init__(self, device_data: DeviceData, queue_timeout: int = 4):
         """Initialize the Roborock local client."""
-        RoborockLocalClient.__init__(self, device_data, queue_timeout)
+        RoborockLocalClient.__init__(self, device_data)
         RoborockClientV1.__init__(self, device_data, "abc")
+        self.queue_timeout = queue_timeout
         self._logger = RoborockLoggerAdapter(device_data.device.name, _LOGGER)
 
     def build_roborock_message(

--- a/roborock/version_1_apis/roborock_mqtt_client_v1.py
+++ b/roborock/version_1_apis/roborock_mqtt_client_v1.py
@@ -32,8 +32,9 @@ class RoborockMqttClientV1(RoborockMqttClient, RoborockClientV1):
             raise RoborockException("Got no rriot data from user_data")
         endpoint = base64.b64encode(Utils.md5(rriot.k.encode())[8:14]).decode()
 
-        RoborockMqttClient.__init__(self, user_data, device_info, queue_timeout)
+        RoborockMqttClient.__init__(self, user_data, device_info)
         RoborockClientV1.__init__(self, device_info, endpoint)
+        self.queue_timeout = queue_timeout
         self._logger = RoborockLoggerAdapter(device_info.device.name, _LOGGER)
 
     async def send_message(self, roborock_message: RoborockMessage):

--- a/roborock/version_a01_apis/roborock_client_a01.py
+++ b/roborock/version_a01_apis/roborock_client_a01.py
@@ -108,9 +108,9 @@ zeo_data_protocol_entries = {
 class RoborockClientA01(RoborockClient, ABC):
     """Roborock client base class for A01 devices."""
 
-    def __init__(self, device_info: DeviceData, category: RoborockCategory, queue_timeout: int = 4):
+    def __init__(self, device_info: DeviceData, category: RoborockCategory):
         """Initialize the Roborock client."""
-        super().__init__(device_info, queue_timeout)
+        super().__init__(device_info)
         self.category = category
 
     def on_message_received(self, messages: list[RoborockMessage]) -> None:

--- a/roborock/version_a01_apis/roborock_mqtt_client_a01.py
+++ b/roborock/version_a01_apis/roborock_mqtt_client_a01.py
@@ -34,8 +34,9 @@ class RoborockMqttClientA01(RoborockMqttClient, RoborockClientA01):
         if rriot is None:
             raise RoborockException("Got no rriot data from user_data")
 
-        RoborockMqttClient.__init__(self, user_data, device_info, queue_timeout)
-        RoborockClientA01.__init__(self, device_info, category, queue_timeout)
+        RoborockMqttClient.__init__(self, user_data, device_info)
+        RoborockClientA01.__init__(self, device_info, category)
+        self.queue_timeout = queue_timeout
         self._logger = RoborockLoggerAdapter(device_info.device.name, _LOGGER)
 
     async def send_message(self, roborock_message: RoborockMessage):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Used by fixtures to handle incoming requests and prepare responses
 RequestHandler = Callable[[bytes], bytes | None]
+QUEUE_TIMEOUT = 10
 
 
 class FakeSocketHandler:
@@ -145,7 +146,7 @@ async def mqtt_client(mock_create_connection: None, mock_select: None) -> AsyncG
         device=home_data.devices[0],
         model=home_data.products[0].model,
     )
-    client = RoborockMqttClientV1(user_data, device_info)
+    client = RoborockMqttClientV1(user_data, device_info, queue_timeout=QUEUE_TIMEOUT)
     try:
         yield client
     finally:
@@ -239,7 +240,7 @@ async def local_client_fixture(mock_create_local_connection: None) -> AsyncGener
         model=home_data.products[0].model,
         host=TEST_LOCAL_API_HOST,
     )
-    client = RoborockLocalClientV1(device_info)
+    yield RoborockLocalClientV1(device_info, queue_timeout=QUEUE_TIMEOUT)
     try:
         yield client
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,7 @@ async def local_client_fixture(mock_create_local_connection: None) -> AsyncGener
         model=home_data.products[0].model,
         host=TEST_LOCAL_API_HOST,
     )
-    yield RoborockLocalClientV1(device_info, queue_timeout=QUEUE_TIMEOUT)
+    client = RoborockLocalClientV1(device_info, queue_timeout=QUEUE_TIMEOUT)
     try:
         yield client
     finally:

--- a/tests/test_a01_api.py
+++ b/tests/test_a01_api.py
@@ -52,7 +52,9 @@ async def a01_mqtt_client_fixture(
         device=home_data.devices[0],
         model=home_data.products[0].model,
     )
-    client = RoborockMqttClientA01(user_data, device_info, RoborockCategory.WASHING_MACHINE, queue_timeout=QUEUE_TIMEOUT)
+    client = RoborockMqttClientA01(
+        user_data, device_info, RoborockCategory.WASHING_MACHINE, queue_timeout=QUEUE_TIMEOUT
+    )
     try:
         yield client
     finally:

--- a/tests/test_a01_api.py
+++ b/tests/test_a01_api.py
@@ -33,6 +33,7 @@ from tests.mock_data import (
 )
 
 from . import mqtt_packet
+from .conftest import QUEUE_TIMEOUT
 
 
 @pytest.fixture(name="a01_mqtt_client")
@@ -51,7 +52,7 @@ async def a01_mqtt_client_fixture(
         device=home_data.devices[0],
         model=home_data.products[0].model,
     )
-    client = RoborockMqttClientA01(user_data, device_info, RoborockCategory.WASHING_MACHINE)
+    client = RoborockMqttClientA01(user_data, device_info, RoborockCategory.WASHING_MACHINE, queue_timeout=QUEUE_TIMEOUT)
     try:
         yield client
     finally:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,7 @@ from tests.mock_data import (
 )
 
 from . import mqtt_packet
+from .conftest import QUEUE_TIMEOUT
 
 
 def test_can_create_prepared_request():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,7 +33,6 @@ from tests.mock_data import (
 )
 
 from . import mqtt_packet
-from .conftest import QUEUE_TIMEOUT
 
 
 def test_can_create_prepared_request():


### PR DESCRIPTION
Update the class hierarchy for queue_timeout so that it is only set in the base classes. Right now it is passed up through the constructors, but sometimes uses the default arguments and get overwritten. This is an example of the problems with having multiple inheritance.

Issue #228

Update the tests to set a timeout of 10 up from 4 to see if it helps the tests be more resilient to slowness.