### PR TITLE
chore: fix flaky tests by cleaning up threads

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1152,6 +1152,20 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.3.1"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9"},
+    {file = "pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1438,4 +1452,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "3f599a64cda4db14b1d2548a2f83adb35a941cf7342281c36003db97bff4434d"
+content-hash = "5bd1bd5697667207cf8d2565fbf84c491d55bcc88cf4de20d58c916f8d941400"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ codespell = "*"
 pyshark = "^0.6"
 aioresponses = "^0.7.7"
 freezegun = "^1.5.1"
+pytest-timeout = "^2.3.1"
 
 [tool.semantic_release]
 branch = "main"
@@ -75,3 +76,4 @@ asyncio_default_fixture_loop_scope = "function"
 log_cli_level = "DEBUG"
 log_format = "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
+timeout = 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,5 @@ select=["E", "F", "UP", "I"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 log_cli_level = "DEBUG"
+log_format = "%(asctime)s %(levelname)s %(name)s:%(filename)s:%(lineno)s %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,5 @@ select=["E", "F", "UP", "I"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 log_cli_level = "DEBUG"
-log_format = "%(asctime)s %(levelname)s %(name)s:%(filename)s:%(lineno)s %(message)s"
+log_format = "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,4 @@ select=["E", "F", "UP", "I"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-log_cli_level = "DEBUG"
-log_format = "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s"
-log_date_format = "%Y-%m-%d %H:%M:%S"
 timeout = 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ select=["E", "F", "UP", "I"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 log_cli_level = "DEBUG"
 log_format = "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,4 @@ select=["E", "F", "UP", "I"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+log_cli_level = "DEBUG"

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -77,8 +77,7 @@ class RoborockMqttClient(RoborockClient, ABC):
     async def async_release(self) -> None:
         """Release the MQTT client."""
         await super().async_release()
-        if self._mqtt_client:
-            await self.event_loop.run_in_executor(None, self._mqtt_client.loop_stop)
+        await self.event_loop.run_in_executor(None, self._mqtt_client.loop_stop)
 
     def _mqtt_on_connect(self, *args, **kwargs):
         _, __, ___, rc, ____ = args

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -162,7 +162,6 @@ class RoborockMqttClient(RoborockClient, ABC):
     async def async_disconnect(self) -> None:
         async with self._mutex:
             if disconnected_future := self.sync_disconnect():
-                # Cleanup the mqtt client threads
                 try:
                     await disconnected_future
                 except VacuumError as err:

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -82,6 +82,8 @@ class RoborockMqttClient(RoborockClient, ABC):
             self._logger.error(message)
             if connection_queue:
                 connection_queue.set_exception(VacuumError(message))
+            else:
+                self._logger.debug("Failed to notify connect future, not in queue")
             return
         self._logger.info(f"Connected to mqtt {self._mqtt_host}:{self._mqtt_port}")
         topic = f"rr/m/o/{self._mqtt_user}/{self._hashed_user}/{self.device_info.device.duid}"

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -156,6 +156,8 @@ class RoborockMqttClient(RoborockClient, ABC):
     async def async_disconnect(self) -> None:
         async with self._mutex:
             if disconnected_future := self.sync_disconnect():
+                # Cleanup the mqtt client threads
+                await self.event_loop.run_in_executor(None, self._mqtt_client.loop_stop)
                 try:
                     await disconnected_future
                 except VacuumError as err:

--- a/roborock/roborock_future.py
+++ b/roborock/roborock_future.py
@@ -33,7 +33,4 @@ class RoborockFuture:
             async with async_timeout.timeout(timeout):
                 return await self.fut
         finally:
-            try:
-                self.fut.cancel()
-            except Exception:
-                pass
+            self.fut.cancel()

--- a/roborock/roborock_future.py
+++ b/roborock/roborock_future.py
@@ -33,4 +33,7 @@ class RoborockFuture:
             async with async_timeout.timeout(timeout):
                 return await self.fut
         finally:
-            self.fut.cancel()
+            try:
+                self.fut.cancel()
+            except Exception:
+                pass

--- a/roborock/version_a01_apis/roborock_client_a01.py
+++ b/roborock/version_a01_apis/roborock_client_a01.py
@@ -128,8 +128,8 @@ class RoborockClientA01(RoborockClient, ABC):
                     continue
                 payload_json = json.loads(payload.decode())
                 for data_point_number, data_point in payload_json.get("dps").items():
-                    self._logger.debug("data point number=%s", data_point_number)
                     data_point_protocol: RoborockDyadDataProtocol | RoborockZeoProtocol
+                    self._logger.debug("received msg with dps, protocol: %s, %s", data_point_number, protocol)
                     entries: dict
                     if self.category == RoborockCategory.WET_DRY_VAC:
                         data_point_protocol = RoborockDyadDataProtocol(int(data_point_number))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import io
 import logging
 import re
 from asyncio import Protocol
-from collections.abc import Callable, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 from queue import Queue
 from typing import Any
 from unittest.mock import Mock, patch
@@ -138,7 +138,7 @@ def select_fixture(mock_sock: Mock, fake_socket_handler: FakeSocketHandler) -> G
 
 
 @pytest.fixture(name="mqtt_client")
-async def mqtt_client(mock_create_connection: None, mock_select: None) -> Generator[RoborockMqttClientV1, None, None]:
+async def mqtt_client(mock_create_connection: None, mock_select: None) -> AsyncGenerator[RoborockMqttClientV1, None]:
     user_data = UserData.from_dict(USER_DATA)
     home_data = HomeData.from_dict(HOME_DATA_RAW)
     device_info = DeviceData(
@@ -232,7 +232,7 @@ def create_local_connection_fixture(request_handler: RequestHandler) -> Generato
 
 
 @pytest.fixture(name="local_client")
-async def local_client_fixture(mock_create_local_connection: None) -> Generator[RoborockLocalClientV1, None, None]:
+async def local_client_fixture(mock_create_local_connection: None) -> AsyncGenerator[RoborockLocalClientV1, None]:
     home_data = HomeData.from_dict(HOME_DATA_RAW)
     device_info = DeviceData(
         device=home_data.devices[0],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ def select_fixture(mock_sock: Mock, fake_socket_handler: FakeSocketHandler) -> G
         return sock is not mock_sock or (fake_socket_handler.pending() > 0)
 
     def handle_select(rlist: list, wlist: list, *args: Any) -> list:
-        return [list(filter(is_ready, rlist)), list(filter(is_ready, wlist))]
+        return [rlist, list(filter(is_ready, wlist))]
 
     with patch("paho.mqtt.client.select.select", side_effect=handle_select):
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ def select_fixture(mock_sock: Mock, fake_socket_handler: FakeSocketHandler) -> G
         return sock is not mock_sock or (fake_socket_handler.pending() > 0)
 
     def handle_select(rlist: list, wlist: list, *args: Any) -> list:
-        return [rlist, list(filter(is_ready, wlist))]
+        return [list(filter(is_ready, rlist)), list(filter(is_ready, wlist))]
 
     with patch("paho.mqtt.client.select.select", side_effect=handle_select):
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,7 +138,7 @@ def select_fixture(mock_sock: Mock, fake_socket_handler: FakeSocketHandler) -> G
 
 
 @pytest.fixture(name="mqtt_client")
-def mqtt_client(mock_create_connection: None, mock_select: None) -> Generator[RoborockMqttClientV1, None, None]:
+async def mqtt_client(mock_create_connection: None, mock_select: None) -> Generator[RoborockMqttClientV1, None, None]:
     user_data = UserData.from_dict(USER_DATA)
     home_data = HomeData.from_dict(HOME_DATA_RAW)
     device_info = DeviceData(
@@ -146,8 +146,14 @@ def mqtt_client(mock_create_connection: None, mock_select: None) -> Generator[Ro
         model=home_data.products[0].model,
     )
     client = RoborockMqttClientV1(user_data, device_info)
-    yield client
-    # Clean up any resources after the test
+    try:
+        yield client
+    finally:
+        if not client.is_connected():
+            try:
+                await client.async_release()
+            except Exception:
+                pass
 
 
 @pytest.fixture(name="mock_rest", autouse=True)
@@ -226,11 +232,19 @@ def create_local_connection_fixture(request_handler: RequestHandler) -> Generato
 
 
 @pytest.fixture(name="local_client")
-def local_client_fixture(mock_create_local_connection: None) -> Generator[RoborockLocalClientV1, None, None]:
+async def local_client_fixture(mock_create_local_connection: None) -> Generator[RoborockLocalClientV1, None, None]:
     home_data = HomeData.from_dict(HOME_DATA_RAW)
     device_info = DeviceData(
         device=home_data.devices[0],
         model=home_data.products[0].model,
         host=TEST_LOCAL_API_HOST,
     )
-    yield RoborockLocalClientV1(device_info)
+    client = RoborockLocalClientV1(device_info)
+    try:
+        yield client
+    finally:
+        if not client.is_connected():
+            try:
+                await client.async_release()
+            except Exception:
+                pass

--- a/tests/test_a01_api.py
+++ b/tests/test_a01_api.py
@@ -174,13 +174,13 @@ async def test_update_values(
 
     message = build_rpc_response(
         {
-            203: [[16, "2362048"], [17, "2362044"]],
+            203: 6,
         }
     )
     response_queue.put(mqtt_packet.gen_publish(MQTT_PUBLISH_TOPIC, payload=message))
 
     data = await connected_a01_mqtt_client.update_values([RoborockZeoProtocol.STATE])
-    assert data.get(RoborockZeoProtocol.STATE) == "standby"
+    assert data.get(RoborockZeoProtocol.STATE) == "spinningdata point number="
 
 
 async def test_publish_failure(

--- a/tests/test_a01_api.py
+++ b/tests/test_a01_api.py
@@ -36,7 +36,7 @@ from . import mqtt_packet
 
 
 @pytest.fixture(name="a01_mqtt_client")
-async def a01_mqtt_client_fixture(mock_create_connection: None, mock_select: None) -> RoborockMqttClientA01:
+async def a01_mqtt_client_fixture(mock_create_connection: None, mock_select: None) -> AsyncGenerator[RoborockMqttClientA01, None]:
     user_data = UserData.from_dict(USER_DATA)
     home_data = HomeData.from_dict(
         {
@@ -49,7 +49,15 @@ async def a01_mqtt_client_fixture(mock_create_connection: None, mock_select: Non
         device=home_data.devices[0],
         model=home_data.products[0].model,
     )
-    return RoborockMqttClientA01(user_data, device_info, RoborockCategory.WASHING_MACHINE)
+    client = RoborockMqttClientA01(user_data, device_info, RoborockCategory.WASHING_MACHINE)
+    try:
+        yield client
+    finally:
+        if not client.is_connected():
+            try:
+                await client.async_release()
+            except Exception:
+                pass
 
 
 @pytest.fixture(name="connected_a01_mqtt_client")

--- a/tests/test_a01_api.py
+++ b/tests/test_a01_api.py
@@ -174,13 +174,13 @@ async def test_update_values(
 
     message = build_rpc_response(
         {
-            203: 6,
+            203: 6,  # spinning
         }
     )
     response_queue.put(mqtt_packet.gen_publish(MQTT_PUBLISH_TOPIC, payload=message))
 
     data = await connected_a01_mqtt_client.update_values([RoborockZeoProtocol.STATE])
-    assert data.get(RoborockZeoProtocol.STATE) == "spinningdata point number="
+    assert data.get(RoborockZeoProtocol.STATE) == "spinning"
 
 
 async def test_publish_failure(

--- a/tests/test_a01_api.py
+++ b/tests/test_a01_api.py
@@ -36,7 +36,9 @@ from . import mqtt_packet
 
 
 @pytest.fixture(name="a01_mqtt_client")
-async def a01_mqtt_client_fixture(mock_create_connection: None, mock_select: None) -> AsyncGenerator[RoborockMqttClientA01, None]:
+async def a01_mqtt_client_fixture(
+    mock_create_connection: None, mock_select: None
+) -> AsyncGenerator[RoborockMqttClientA01, None]:
     user_data = UserData.from_dict(USER_DATA)
     home_data = HomeData.from_dict(
         {


### PR DESCRIPTION
Explicitly stop the mqtt loop when the client library shuts down to avoid leaking threads. Explicitly release clients during test cleanup, but make it best effort.