### PR TITLE
fix: log an explicit message when intentionally resetting the connection

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -91,6 +91,7 @@ class RoborockClient(ABC):
 
     async def validate_connection(self) -> None:
         if not self.should_keepalive():
+            self._logger.info("Resetting Roborock connection due to kepalive timeout")
             await self.async_disconnect()
         await self.async_connect()
 


### PR DESCRIPTION
Update the keepalive logic to log an error message so that we can diagnose disconnects as coming from the device vs being originated by the keepalive logic.