### PR TITLE
refactor: breaking change to remove sync APIs

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -91,6 +91,7 @@ class RoborockClient(ABC):
 
     async def validate_connection(self) -> None:
         if not self.should_keepalive():
+            self._logger.info("Resetting Roborock connection due to kepalive timeout")
             await self.async_disconnect()
         await self.async_connect()
 

--- a/roborock/api.py
+++ b/roborock/api.py
@@ -48,10 +48,8 @@ class RoborockClient(ABC):
         self.queue_timeout = queue_timeout
 
     def __del__(self) -> None:
-        self.release()
-
-    def release(self) -> None:
-        self.sync_disconnect()
+        if self.is_connected():
+            self._logger.warning("Roborock client was not released properly")
 
     async def async_release(self) -> None:
         await self.async_disconnect()
@@ -65,12 +63,12 @@ class RoborockClient(ABC):
         """Connect to the Roborock device."""
 
     @abstractmethod
-    def sync_disconnect(self) -> Any:
+    async def async_disconnect(self) -> Any:
         """Disconnect from the Roborock device."""
 
     @abstractmethod
-    async def async_disconnect(self) -> Any:
-        """Disconnect from the Roborock device."""
+    def is_connected(self) -> bool:
+        """Return True if the client is connected to the device."""
 
     @abstractmethod
     def on_message_received(self, messages: list[RoborockMessage]) -> None:

--- a/roborock/api.py
+++ b/roborock/api.py
@@ -49,7 +49,7 @@ class RoborockClient(ABC):
 
     def __del__(self) -> None:
         if self.is_connected():
-            self._logger.warning("Roborock client was not released properly")
+            self._logger.debug("Roborock is connected while being released")
 
     async def async_release(self) -> None:
         await self.async_disconnect()

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -121,7 +121,7 @@ class RoborockMqttClient(RoborockClient, ABC):
         """Check if the mqtt client is connected."""
         return self._mqtt_client.is_connected()
 
-    def sync_disconnect(self) -> Any:
+    def _sync_disconnect(self) -> Any:
         if not self.is_connected():
             return None
 
@@ -139,7 +139,7 @@ class RoborockMqttClient(RoborockClient, ABC):
 
         return disconnected_future
 
-    def sync_connect(self) -> Any:
+    def _sync_connect(self) -> Any:
         if self.is_connected():
             self._mqtt_client.maybe_restart_loop()
             return None
@@ -155,14 +155,14 @@ class RoborockMqttClient(RoborockClient, ABC):
 
     async def async_disconnect(self) -> None:
         async with self._mutex:
-            if disconnected_future := self.sync_disconnect():
+            if disconnected_future := self._sync_disconnect():
                 # There are no errors set on this future
                 await disconnected_future
             await self.event_loop.run_in_executor(None, self._mqtt_client.loop_stop)
 
     async def async_connect(self) -> None:
         async with self._mutex:
-            if connected_future := self.sync_connect():
+            if connected_future := self._sync_connect():
                 try:
                     await connected_future
                 except VacuumError as err:

--- a/roborock/local_api.py
+++ b/roborock/local_api.py
@@ -61,7 +61,7 @@ class RoborockLocalClient(RoborockClient, ABC):
 
     def _connection_lost(self, exc: Exception | None):
         """Called when the transport connection is lost."""
-        self.sync_disconnect()
+        self._sync_disconnect()
         self.on_connection_lost(exc)
 
     def is_connected(self):
@@ -79,7 +79,7 @@ class RoborockLocalClient(RoborockClient, ABC):
         async with self._mutex:
             try:
                 if not self.is_connected():
-                    self.sync_disconnect()
+                    self._sync_disconnect()
                     async with async_timeout.timeout(self.queue_timeout):
                         self._logger.debug(f"Connecting to {self.host}")
                         self.transport, _ = await self.event_loop.create_connection(  # type: ignore
@@ -93,7 +93,7 @@ class RoborockLocalClient(RoborockClient, ABC):
             await self.hello()
             await self.keep_alive_func()
 
-    def sync_disconnect(self) -> None:
+    def _sync_disconnect(self) -> None:
         if self.transport and self.event_loop.is_running():
             self._logger.debug(f"Disconnecting from {self.host}")
             self.transport.close()
@@ -102,7 +102,7 @@ class RoborockLocalClient(RoborockClient, ABC):
 
     async def async_disconnect(self) -> None:
         async with self._mutex:
-            self.sync_disconnect()
+            self._sync_disconnect()
 
     async def hello(self):
         request_id = 1

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -164,10 +164,6 @@ class RoborockClientV1(RoborockClient, ABC):
         self.listener_model = self._listeners[device_info.device.duid]
         self._endpoint = endpoint
 
-    def release(self):
-        super().release()
-        [item.stop() for item in self.cache.values()]
-
     async def async_release(self) -> None:
         await super().async_release()
         [item.stop() for item in self.cache.values()]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,15 +45,6 @@ async def test_can_create_mqtt_roborock():
     RoborockMqttClientV1(UserData.from_dict(USER_DATA), device_info)
 
 
-async def test_sync_connect(mqtt_client):
-    with patch("paho.mqtt.client.Client.connect", return_value=mqtt.MQTT_ERR_SUCCESS):
-        with patch("paho.mqtt.client.Client.loop_start", return_value=mqtt.MQTT_ERR_SUCCESS):
-            connected_future = mqtt_client.sync_connect()
-            assert connected_future is not None
-
-            connected_future.cancel()
-
-
 async def test_get_base_url_no_url():
     rc = RoborockApiClient("sample@gmail.com")
     with patch("roborock.web_api.PreparedRequest.request") as mock_request:


### PR DESCRIPTION
Two breaking changes:
- Remove the sync APIs. Callers need to update from the `sync_` version to the fully `async_` version. These APIs currenty log warnings when not called from an async when an event loop is not started.
- These APIs will now log when the client library is not shutdown properly. The caller must call the async release methods when shutting down to free any resources rather than relying on the `__del__` method which is not async. This is logged at debug since i'm not sure how reliable it is to check "is_connected"

Issue #228