### PR TITLE
fix: remove the __del__ warning for disconnected clients

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -47,10 +47,6 @@ class RoborockClient(ABC):
         }
         self.is_available: bool = True
 
-    def __del__(self) -> None:
-        if self.is_connected():
-            self._logger.debug("Roborock is connected while being released")
-
     async def async_release(self) -> None:
         await self.async_disconnect()
 


### PR DESCRIPTION
This had some problems in home assistants unit test. I think it is reasonable to just require clients to shut down things properly and not have this.

This is needed to update python-roborock in Home Assistant.