### PR TITLE
fix: never create a new asyncio loop

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -21,7 +21,7 @@ from .roborock_future import RoborockFuture
 from .roborock_message import (
     RoborockMessage,
 )
-from .util import get_next_int, get_running_loop_or_create_one
+from .util import get_next_int
 
 _LOGGER = logging.getLogger(__name__)
 KEEPALIVE = 60
@@ -35,7 +35,6 @@ class RoborockClient(ABC):
 
     def __init__(self, device_info: DeviceData) -> None:
         """Initialize RoborockClient."""
-        self.event_loop = get_running_loop_or_create_one()
         self.device_info = device_info
         self._nonce = secrets.token_bytes(16)
         self._waiting_queue: dict[int, RoborockFuture] = {}

--- a/roborock/cloud_api.py
+++ b/roborock/cloud_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 from abc import ABC
@@ -158,7 +159,8 @@ class RoborockMqttClient(RoborockClient, ABC):
             if disconnected_future := self._sync_disconnect():
                 # There are no errors set on this future
                 await disconnected_future
-            await self.event_loop.run_in_executor(None, self._mqtt_client.loop_stop)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._mqtt_client.loop_stop)
 
     async def async_connect(self) -> None:
         async with self._mutex:

--- a/roborock/util.py
+++ b/roborock/util.py
@@ -74,8 +74,7 @@ def run_sync():
 
 
 class RepeatableTask:
-    def __init__(self, loop: AbstractEventLoop, callback: Callable[[], Coroutine], interval: int):
-        self.loop = loop
+    def __init__(self, callback: Callable[[], Coroutine], interval: int):
         self.callback = callback
         self.interval = interval
         self._task: TimerHandle | None = None
@@ -86,7 +85,8 @@ class RepeatableTask:
             response = await self.callback()
         except RoborockException:
             pass
-        self._task = self.loop.call_later(self.interval, self._run_task_soon)
+        loop = asyncio.get_running_loop()
+        self._task = loop.call_later(self.interval, self._run_task_soon)
         return response
 
     def _run_task_soon(self):

--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -82,11 +82,11 @@ _SendCommandT = Callable[[RoborockCommand | str, list | dict | int | None], Any]
 
 
 class AttributeCache:
-    def __init__(self, attribute: RoborockAttribute, loop: asyncio.AbstractEventLoop, send_command: _SendCommandT):
+    def __init__(self, attribute: RoborockAttribute, send_command: _SendCommandT):
         self.attribute = attribute
         self._send_command = send_command
         self.attribute = attribute
-        self.task = RepeatableTask(loop, self._async_value, EVICT_TIME)
+        self.task = RepeatableTask(self._async_value, EVICT_TIME)
         self._value: Any = None
         self._mutex = asyncio.Lock()
         self.unsupported: bool = False
@@ -156,7 +156,7 @@ class RoborockClientV1(RoborockClient, ABC):
         super().__init__(device_info)
         self._status_type: type[Status] = ModelStatus.get(device_info.model, S7MaxVStatus)
         self.cache: dict[CacheableAttribute, AttributeCache] = {
-            cacheable_attribute: AttributeCache(attr, self.event_loop, self._send_command)
+            cacheable_attribute: AttributeCache(attr, self._send_command)
             for cacheable_attribute, attr in get_cache_map().items()
         }
         if device_info.device.duid not in self._listeners:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,7 +227,7 @@ def create_local_connection_fixture(request_handler: RequestHandler) -> Generato
 
         return (mock_transport, "proto")
 
-    with patch("roborock.api.get_running_loop_or_create_one") as mock_loop:
+    with patch("roborock.local_api.get_running_loop") as mock_loop:
         mock_loop.return_value.create_connection.side_effect = create_connection
         yield
 


### PR DESCRIPTION
Always reuse the existing asyncio loop rather than creating a new one.

This is needed to upgrade python-roborock in Home Assistant since the async shutdown call must happen in the same asyncio loop that was used to create the client.

This requires inlining all calls to get the currently running loop, because the constructor for the MQTT client needs to be created from outside the asyncio loop because the MQTT client does blocking I/O in the constructor. (example: https://github.com/home-assistant/core/pull/124266). In the future we can move this back to the constructor, but that requires separately creating the MQTT client in a way that doesn't block, which we can do in the future when using a shared MQTT client as proposed by @Lash-L.

