### PR TITLE
fix: ignore ping id during id check

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -20,6 +20,7 @@ from .exceptions import (
 from .roborock_future import RoborockFuture
 from .roborock_message import (
     RoborockMessage,
+    RoborockMessageProtocol,
 )
 from .util import get_next_int
 
@@ -101,7 +102,9 @@ class RoborockClient(ABC):
 
     def _async_response(self, request_id: int, protocol_id: int = 0) -> Any:
         queue = RoborockFuture(protocol_id)
-        if request_id in self._waiting_queue:
+        if request_id in self._waiting_queue and not (
+            request_id == 2 and protocol_id == RoborockMessageProtocol.PING_REQUEST
+        ):
             new_id = get_next_int(10000, 32767)
             self._logger.warning(
                 "Attempting to create a future with an existing id %s (%s)... New id is %s. "


### PR DESCRIPTION
Ping will always have the same id and there is a strong likelihood that two could be in the waiting queue at the same time and that should be fine for aping


relates to: https://github.com/home-assistant/core/issues/136908#issuecomment-2624484017

This does not fix the relating problem that when an id changes, the system doesn't know how to wait for it.