### PR TITLE
feat: add load_multi_map function

### DIFF
--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -336,6 +336,10 @@ class RoborockClientV1(RoborockClient, ABC):
             return [ServerTimer(*server_timers)]
         return []
 
+    async def load_multi_map(self, map_flag: int) -> None:
+        """Load the map into the vacuum's memory."""
+        await self.send_command(RoborockCommand.LOAD_MULTI_MAP, [map_flag])
+
     def _get_payload(
         self,
         method: RoborockCommand | str,


### PR DESCRIPTION
Not really a huge deal - but this means we don't have to do self.coord.api.send_command(RoborockCommand.LOAD_MULTI_MAP, [map_flag])

It can be a lot easier and cleaner.