### PR TITLE
Add dock type code 18 for Saros 10

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -465,6 +465,7 @@ class RoborockDockTypeCode(RoborockEnum):
     qrevo_s_dock = 15
     saros_r10_dock = 16
     qrevo_curv_dock = 17
+    saros_10_dock = 18
 
 
 class RoborockDockDustCollectionModeCode(RoborockEnum):


### PR DESCRIPTION
My Roborock Saros 10 is showing a warning log in Home Assistant:

```
Logger: roborock.code_mappings
Source: runner.py:154
First occurred: 17:29:15 (1 occurrences)
Last logged: 17:29:15

Missing RoborockDockTypeCode code: 18 - defaulting to 'unknown'
```

Implemented a similar fix to https://github.com/Python-roborock/python-roborock/pull/343 - Adding the code to `RoborockDockTypeCode`.