### PR TITLE
Make error code consistent for dock and robot

### DIFF
--- a/roborock/code_mappings.py
+++ b/roborock/code_mappings.py
@@ -473,7 +473,7 @@ class RoborockMopIntensityQ7Max(RoborockMopIntensityCode):
 class RoborockDockErrorCode(RoborockEnum):
     """Describes the error code of the dock."""
 
-    ok = 0
+    none = 0
     duct_blockage = 34
     water_empty = 38
     waste_water_tank_full = 39


### PR DESCRIPTION
When everything is ok the robot reports 'none' while the dock 'ok', while they both should report 'none' reflecting no errors.