### PR TITLE
feat: Update device manager and device to establish an MQTT subscription

### DIFF
--- a/roborock/devices/device.py
+++ b/roborock/devices/device.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from functools import cached_property
 
 from roborock.containers import HomeDataDevice, HomeDataProduct, UserData
+from roborock.roborock_message import RoborockMessage
 
 from .mqtt_channel import MqttChannel
 
@@ -99,9 +100,9 @@ class RoborockDevice:
             self._unsub()
             self._unsub = None
 
-    def _on_mqtt_message(self, message: bytes) -> None:
+    def _on_mqtt_message(self, message: RoborockMessage) -> None:
         """Handle incoming MQTT messages from the device.
 
         This method should be overridden in subclasses to handle specific device messages.
         """
-        _LOGGER.debug("Received message from device %s: %s", self.duid, message[:50])  # Log first 50 bytes for brevity
+        _LOGGER.debug("Received message from device %s: %s", self.duid, message)

--- a/roborock/devices/device.py
+++ b/roborock/devices/device.py
@@ -10,6 +10,8 @@ from functools import cached_property
 
 from roborock.containers import HomeDataDevice, HomeDataProduct, UserData
 
+from .mqtt_channel import MqttChannel
+
 _LOGGER = logging.getLogger(__name__)
 
 __all__ = [
@@ -29,11 +31,22 @@ class DeviceVersion(enum.StrEnum):
 class RoborockDevice:
     """Unified Roborock device class with automatic connection setup."""
 
-    def __init__(self, user_data: UserData, device_info: HomeDataDevice, product_info: HomeDataProduct) -> None:
-        """Initialize the RoborockDevice with device info, user data, and capabilities."""
+    def __init__(
+        self,
+        user_data: UserData,
+        device_info: HomeDataDevice,
+        product_info: HomeDataProduct,
+        mqtt_channel: MqttChannel,
+    ) -> None:
+        """Initialize the RoborockDevice.
+
+        The device takes ownership of the MQTT channel for communication with the device
+        and will close it when the device is closed.
+        """
         self._user_data = user_data
         self._device_info = device_info
         self._product_info = product_info
+        self._mqtt_channel = mqtt_channel
 
     @property
     def duid(self) -> str:
@@ -63,3 +76,24 @@ class RoborockDevice:
             self._device_info.name,
         )
         return DeviceVersion.UNKNOWN
+
+    async def connect(self) -> None:
+        """Connect to the device using MQTT.
+
+        This method will set up the MQTT channel for communication with the device.
+        """
+        await self._mqtt_channel.subscribe(self._on_mqtt_message)
+
+    async def close(self) -> None:
+        """Close the MQTT connection to the device.
+
+        This method will unsubscribe from the MQTT channel and clean up resources.
+        """
+        await self._mqtt_channel.close()
+
+    def _on_mqtt_message(self, message: bytes) -> None:
+        """Handle incoming MQTT messages from the device.
+
+        This method should be overridden in subclasses to handle specific device messages.
+        """
+        _LOGGER.debug("Received message from device %s: %s", self.duid, message[:50])  # Log first 50 bytes for brevity

--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -113,7 +113,7 @@ async def create_device_manager(user_data: UserData, home_data_api: HomeDataApi)
     mqtt_session = await create_mqtt_session(mqtt_params)
 
     def device_creator(device: HomeDataDevice, product: HomeDataProduct) -> RoborockDevice:
-        mqtt_channel = MqttChannel(mqtt_session, device.duid, user_data.rriot, mqtt_params)
+        mqtt_channel = MqttChannel(mqtt_session, device.duid, device.local_key, user_data.rriot, mqtt_params)
         return RoborockDevice(user_data, device, product, mqtt_channel)
 
     manager = DeviceManager(home_data_api, device_creator, mqtt_session=mqtt_session)

--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -10,7 +10,12 @@ from roborock.containers import (
     UserData,
 )
 from roborock.devices.device import RoborockDevice
+from roborock.mqtt.roborock_session import create_mqtt_session
+from roborock.mqtt.session import MqttSession
+from roborock.protocol import create_mqtt_params
 from roborock.web_api import RoborockApiClient
+
+from .mqtt_channel import MqttChannel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,11 +39,16 @@ class DeviceManager:
         self,
         home_data_api: HomeDataApi,
         device_creator: DeviceCreator,
+        mqtt_session: MqttSession,
     ) -> None:
-        """Initialize the DeviceManager with user data and optional cache storage."""
+        """Initialize the DeviceManager with user data and optional cache storage.
+
+        This takes ownership of the MQTT session and will close it when the manager is closed.
+        """
         self._home_data_api = home_data_api
         self._device_creator = device_creator
         self._devices: dict[str, RoborockDevice] = {}
+        self._mqtt_session = mqtt_session
 
     async def discover_devices(self) -> list[RoborockDevice]:
         """Discover all devices for the logged-in user."""
@@ -46,9 +56,15 @@ class DeviceManager:
         device_products = home_data.device_products
         _LOGGER.debug("Discovered %d devices %s", len(device_products), home_data)
 
-        self._devices = {
-            duid: self._device_creator(device, product) for duid, (device, product) in device_products.items()
-        }
+        new_devices = {}
+        for duid, (device, product) in device_products.items():
+            if duid in self._devices:
+                continue
+            new_device = self._device_creator(device, product)
+            await new_device.connect()
+            new_devices[duid] = new_device
+
+        self._devices.update(new_devices)
         return list(self._devices.values())
 
     async def get_device(self, duid: str) -> RoborockDevice | None:
@@ -59,6 +75,14 @@ class DeviceManager:
         """Get all discovered devices."""
         return list(self._devices.values())
 
+    async def close(self) -> None:
+        """Close all MQTT connections and clean up resources."""
+        for device in self._devices.values():
+            await device.close()
+        self._devices.clear()
+        if self._mqtt_session:
+            await self._mqtt_session.close()
+
 
 def create_home_data_api(email: str, user_data: UserData) -> HomeDataApi:
     """Create a home data API wrapper.
@@ -67,7 +91,9 @@ def create_home_data_api(email: str, user_data: UserData) -> HomeDataApi:
     home data for the user.
     """
 
-    client = RoborockApiClient(email, user_data)
+    # Note: This will auto discover the API base URL. This can be improved
+    # by caching this next to `UserData` if needed to avoid unnecessary API calls.
+    client = RoborockApiClient(email)
 
     async def home_data_api() -> HomeData:
         return await client.get_home_data(user_data)
@@ -83,9 +109,13 @@ async def create_device_manager(user_data: UserData, home_data_api: HomeDataApi)
     include caching or other optimizations.
     """
 
-    def device_creator(device: HomeDataDevice, product: HomeDataProduct) -> RoborockDevice:
-        return RoborockDevice(user_data, device, product)
+    mqtt_params = create_mqtt_params(user_data.rriot)
+    mqtt_session = await create_mqtt_session(mqtt_params)
 
-    manager = DeviceManager(home_data_api, device_creator)
+    def device_creator(device: HomeDataDevice, product: HomeDataProduct) -> RoborockDevice:
+        mqtt_channel = MqttChannel(mqtt_session, device.duid, user_data.rriot, mqtt_params)
+        return RoborockDevice(user_data, device, product, mqtt_channel)
+
+    manager = DeviceManager(home_data_api, device_creator, mqtt_session=mqtt_session)
     await manager.discover_devices()
     return manager

--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -32,7 +32,6 @@ class MqttChannel:
         self._waiting_queue: dict[int, asyncio.Future[RoborockMessage]] = {}
         self._decoder = create_mqtt_decoder(local_key)
         self._encoder = create_mqtt_encoder(local_key)
-        # Use a regular lock since we need to access from sync callback
         self._queue_lock = asyncio.Lock()
 
     @property
@@ -61,6 +60,7 @@ class MqttChannel:
                 _LOGGER.warning("Failed to decode MQTT message: %s", payload)
                 return
             for message in messages:
+                _LOGGER.debug("Received message: %s", message)
                 asyncio.create_task(self._resolve_future_with_lock(message))
                 try:
                     callback(message)

--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -19,7 +19,6 @@ class MqttChannel:
         self._duid = duid
         self._rriot = rriot
         self._mqtt_params = mqtt_params
-        self._unsub: Callable[[], None] | None = None
 
     @property
     def _publish_topic(self) -> str:

--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -1,24 +1,39 @@
+"""Modules for communicating with specific Roborock devices over MQTT."""
+
+import asyncio
 import logging
 from collections.abc import Callable
+from json import JSONDecodeError
 
 from roborock.containers import RRiot
+from roborock.exceptions import RoborockException
 from roborock.mqtt.session import MqttParams, MqttSession
+from roborock.protocol import create_mqtt_decoder, create_mqtt_encoder
+from roborock.roborock_message import RoborockMessage
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class MqttChannel:
-    """RPC-style channel for communicating with a specific device over MQTT.
+    """Simple RPC-style channel for communicating with a device over MQTT.
 
-    This currently only supports listening to messages and does not yet
-    support RPC functionality.
+    Handles request/response correlation and timeouts, but leaves message
+    format most parsing to higher-level components.
     """
 
-    def __init__(self, mqtt_session: MqttSession, duid: str, rriot: RRiot, mqtt_params: MqttParams):
+    def __init__(self, mqtt_session: MqttSession, duid: str, local_key: str, rriot: RRiot, mqtt_params: MqttParams):
         self._mqtt_session = mqtt_session
         self._duid = duid
+        self._local_key = local_key
         self._rriot = rriot
         self._mqtt_params = mqtt_params
+
+        # RPC support
+        self._waiting_queue: dict[int, asyncio.Future[RoborockMessage]] = {}
+        self._decoder = create_mqtt_decoder(local_key)
+        self._encoder = create_mqtt_encoder(local_key)
+        # Use a regular lock since we need to access from sync callback
+        self._queue_lock = asyncio.Lock()
 
     @property
     def _publish_topic(self) -> str:
@@ -30,11 +45,72 @@ class MqttChannel:
         """Topic to receive responses from the device."""
         return f"rr/m/o/{self._rriot.u}/{self._mqtt_params.username}/{self._duid}"
 
-    async def subscribe(self, callback: Callable[[bytes], None]) -> Callable[[], None]:
+    async def subscribe(self, callback: Callable[[RoborockMessage], None]) -> Callable[[], None]:
         """Subscribe to the device's response topic.
 
         The callback will be called with the message payload when a message is received.
 
+        All messages received will be processed through the provided callback, even
+        those sent in response to the `send_command` command.
+
         Returns a callable that can be used to unsubscribe from the topic.
         """
-        return await self._mqtt_session.subscribe(self._subscribe_topic, callback)
+
+        def message_handler(payload: bytes) -> None:
+            if not (messages := self._decoder(payload)):
+                _LOGGER.warning("Failed to decode MQTT message: %s", payload)
+                return
+            for message in messages:
+                asyncio.create_task(self._resolve_future_with_lock(message))
+                try:
+                    callback(message)
+                except Exception as e:
+                    _LOGGER.exception("Uncaught error in message handler callback: %s", e)
+
+        return await self._mqtt_session.subscribe(self._subscribe_topic, message_handler)
+
+    async def _resolve_future_with_lock(self, message: RoborockMessage) -> None:
+        """Resolve waiting future with proper locking."""
+        if (request_id := message.get_request_id()) is None:
+            _LOGGER.debug("Received message with no request_id")
+            return
+        async with self._queue_lock:
+            if (future := self._waiting_queue.pop(request_id, None)) is not None:
+                if not future.done():
+                    future.set_result(message)
+                else:
+                    _LOGGER.warning("Received message for completed future: request_id=%s", request_id)
+            else:
+                _LOGGER.warning("Received message with no waiting handler: request_id=%s", request_id)
+
+    async def send_command(self, message: RoborockMessage, timeout: float = 10.0) -> RoborockMessage:
+        """Send a command message and wait for the response message.
+
+        Returns the raw response message - caller is responsible for parsing.
+        """
+        try:
+            if (request_id := message.get_request_id()) is None:
+                raise RoborockException("Message must have a request_id for RPC calls")
+        except (ValueError, JSONDecodeError) as err:
+            _LOGGER.exception("Error getting request_id from message: %s", err)
+            raise RoborockException(f"Invalid message format, Message must have a request_id: {err}") from err
+
+        future: asyncio.Future[RoborockMessage] = asyncio.Future()
+        async with self._queue_lock:
+            self._waiting_queue[request_id] = future
+
+        try:
+            encoded_msg = self._encoder(message)
+            await self._mqtt_session.publish(self._publish_topic, encoded_msg)
+
+            return await asyncio.wait_for(future, timeout=timeout)
+
+        except asyncio.TimeoutError as ex:
+            async with self._queue_lock:
+                self._waiting_queue.pop(request_id, None)
+            raise RoborockException(f"Command timed out after {timeout}s") from ex
+        except Exception:
+            logging.exception("Uncaught error sending command")
+            async with self._queue_lock:
+                self._waiting_queue.pop(request_id, None)
+            raise

--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -31,14 +31,14 @@ class MqttChannel:
         """Topic to receive responses from the device."""
         return f"rr/m/o/{self._rriot.u}/{self._mqtt_params.username}/{self._duid}"
 
-    async def subscribe(self, callback: Callable[[bytes], None]) -> None:
-        """Subscribe to the device's response topic."""
+    async def subscribe(self, callback: Callable[[bytes], None]) -> Callable[[], None]:
+        """Subscribe to the device's response topic.
+
+        The callback will be called with the message payload when a message is received.
+        If already subscribed, raises ValueError.
+
+        Returns a callable that can be used to unsubscribe from the topic.
+        """
         if self._unsub:
             raise ValueError("Already subscribed to the response topic")
-        self._unsub = await self._mqtt_session.subscribe(self._subscribe_topic, callback)
-
-    async def close(self) -> None:
-        """Close the MQTT subscription."""
-        if self._unsub:
-            self._unsub()
-            self._unsub = None
+        return await self._mqtt_session.subscribe(self._subscribe_topic, callback)

--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -34,10 +34,7 @@ class MqttChannel:
         """Subscribe to the device's response topic.
 
         The callback will be called with the message payload when a message is received.
-        If already subscribed, raises ValueError.
 
         Returns a callable that can be used to unsubscribe from the topic.
         """
-        if self._unsub:
-            raise ValueError("Already subscribed to the response topic")
         return await self._mqtt_session.subscribe(self._subscribe_topic, callback)

--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -1,0 +1,44 @@
+import logging
+from collections.abc import Callable
+
+from roborock.containers import RRiot
+from roborock.mqtt.session import MqttParams, MqttSession
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MqttChannel:
+    """RPC-style channel for communicating with a specific device over MQTT.
+
+    This currently only supports listening to messages and does not yet
+    support RPC functionality.
+    """
+
+    def __init__(self, mqtt_session: MqttSession, duid: str, rriot: RRiot, mqtt_params: MqttParams):
+        self._mqtt_session = mqtt_session
+        self._duid = duid
+        self._rriot = rriot
+        self._mqtt_params = mqtt_params
+        self._unsub: Callable[[], None] | None = None
+
+    @property
+    def _publish_topic(self) -> str:
+        """Topic to send commands to the device."""
+        return f"rr/m/i/{self._rriot.u}/{self._mqtt_params.username}/{self._duid}"
+
+    @property
+    def _subscribe_topic(self) -> str:
+        """Topic to receive responses from the device."""
+        return f"rr/m/o/{self._rriot.u}/{self._mqtt_params.username}/{self._duid}"
+
+    async def subscribe(self, callback: Callable[[bytes], None]) -> None:
+        """Subscribe to the device's response topic."""
+        if self._unsub:
+            raise ValueError("Already subscribed to the response topic")
+        self._unsub = await self._mqtt_session.subscribe(self._subscribe_topic, callback)
+
+    async def close(self) -> None:
+        """Close the MQTT subscription."""
+        if self._unsub:
+            self._unsub()
+            self._unsub = None

--- a/tests/devices/test_device.py
+++ b/tests/devices/test_device.py
@@ -1,0 +1,40 @@
+"""Tests for the Device class."""
+
+from unittest.mock import AsyncMock, Mock
+
+from roborock.containers import HomeData, UserData
+from roborock.devices.device import DeviceVersion, RoborockDevice
+
+from .. import mock_data
+
+USER_DATA = UserData.from_dict(mock_data.USER_DATA)
+HOME_DATA = HomeData.from_dict(mock_data.HOME_DATA_RAW)
+
+
+async def test_device_connection() -> None:
+    """Test the Device connection setup."""
+
+    unsub = Mock()
+    subscribe = AsyncMock()
+    subscribe.return_value = unsub
+    mqtt_channel = AsyncMock()
+    mqtt_channel.subscribe = subscribe
+
+    device = RoborockDevice(
+        USER_DATA,
+        device_info=HOME_DATA.devices[0],
+        product_info=HOME_DATA.products[0],
+        mqtt_channel=mqtt_channel,
+    )
+    assert device.duid == "abc123"
+    assert device.name == "Roborock S7 MaxV"
+    assert device.device_version == DeviceVersion.V1
+
+    assert not subscribe.called
+
+    await device.connect()
+    assert subscribe.called
+    assert not unsub.called
+
+    await device.close()
+    assert unsub.called

--- a/tests/devices/test_device_manager.py
+++ b/tests/devices/test_device_manager.py
@@ -60,12 +60,15 @@ async def test_with_device() -> None:
     assert device.name == "Roborock S7 MaxV"
     assert device.device_version == DeviceVersion.V1
 
+    await device_manager.close()
+
 
 async def test_get_non_existent_device() -> None:
     """Test getting a non-existent device."""
     device_manager = await create_device_manager(USER_DATA, mock_home_data)
     device = await device_manager.get_device("non_existent_duid")
     assert device is None
+    await device_manager.close()
 
 
 async def test_home_data_api_exception() -> None:

--- a/tests/devices/test_device_manager.py
+++ b/tests/devices/test_device_manager.py
@@ -1,5 +1,6 @@
 """Tests for the DeviceManager class."""
 
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +13,13 @@ from roborock.exceptions import RoborockException
 from .. import mock_data
 
 USER_DATA = UserData.from_dict(mock_data.USER_DATA)
+
+
+@pytest.fixture(autouse=True)
+def setup_mqtt_session() -> Generator[None, None, None]:
+    """Fixture to set up the MQTT session for the tests."""
+    with patch("roborock.devices.device_manager.create_mqtt_session"):
+        yield
 
 
 async def home_home_data_no_devices() -> HomeData:

--- a/tests/devices/test_mqtt_channel.py
+++ b/tests/devices/test_mqtt_channel.py
@@ -1,13 +1,18 @@
 """Tests for the MqttChannel class."""
 
-from collections.abc import Generator
+import asyncio
+import json
+from collections.abc import Callable, Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from roborock.containers import HomeData, UserData
 from roborock.devices.mqtt_channel import MqttChannel
+from roborock.exceptions import RoborockException
 from roborock.mqtt.session import MqttParams
+from roborock.protocol import Decoder, Encoder, create_mqtt_decoder, create_mqtt_encoder
+from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 
 from .. import mock_data
 
@@ -20,13 +25,61 @@ TEST_MQTT_PARAMS = MqttParams(
     password="password",
     timeout=10.0,
 )
+TEST_LOCAL_KEY = "local_key"
+
+TEST_REQUEST = RoborockMessage(
+    protocol=RoborockMessageProtocol.RPC_REQUEST,
+    payload=json.dumps({"dps": {"101": json.dumps({"id": 12345, "method": "get_status"})}}).encode(),
+)
+TEST_RESPONSE = RoborockMessage(
+    protocol=RoborockMessageProtocol.RPC_RESPONSE,
+    payload=json.dumps({"dps": {"102": json.dumps({"id": 12345, "result": {"state": "cleaning"}})}}).encode(),
+)
+TEST_REQUEST2 = RoborockMessage(
+    protocol=RoborockMessageProtocol.RPC_REQUEST,
+    payload=json.dumps({"dps": {"101": json.dumps({"id": 54321, "method": "get_status"})}}).encode(),
+)
+TEST_RESPONSE2 = RoborockMessage(
+    protocol=RoborockMessageProtocol.RPC_RESPONSE,
+    payload=json.dumps({"dps": {"102": json.dumps({"id": 54321, "result": {"state": "cleaning"}})}}).encode(),
+)
+ENCODER = create_mqtt_encoder(TEST_LOCAL_KEY)
+DECODER = create_mqtt_decoder(TEST_LOCAL_KEY)
 
 
-@pytest.fixture(autouse=True)
-def setup_mqtt_session() -> Generator[None, None, None]:
+@pytest.fixture(name="mqtt_session", autouse=True)
+def setup_mqtt_session() -> Generator[Mock, None, None]:
     """Fixture to set up the MQTT session for the tests."""
-    with patch("roborock.devices.device_manager.create_mqtt_session"):
-        yield
+    mock_session = AsyncMock()
+    with patch("roborock.devices.device_manager.create_mqtt_session", return_value=mock_session):
+        yield mock_session
+
+
+@pytest.fixture(name="mqtt_channel", autouse=True)
+def setup_mqtt_channel(mqtt_session: Mock) -> MqttChannel:
+    """Fixture to set up the MQTT channel for the tests."""
+    return MqttChannel(
+        mqtt_session, duid="abc123", local_key=TEST_LOCAL_KEY, rriot=USER_DATA.rriot, mqtt_params=TEST_MQTT_PARAMS
+    )
+
+
+@pytest.fixture(name="received_messages", autouse=True)
+async def setup_subscribe_callback(mqtt_channel: MqttChannel) -> list[RoborockMessage]:
+    """Fixture to record messages received by the subscriber."""
+    messages: list[RoborockMessage] = []
+    await mqtt_channel.subscribe(messages.append)
+    return messages
+
+
+@pytest.fixture(name="mqtt_message_handler")
+async def setup_message_handler(mqtt_session: Mock, mqtt_channel: MqttChannel) -> Callable[[bytes], None]:
+    """Fixture to allow simulating incoming MQTT messages."""
+    # Subscribe to set up message handling. We grab the message handler callback
+    # and use it to simulate receiving a response.
+    assert mqtt_session.subscribe
+    subscribe_call_args = mqtt_session.subscribe.call_args
+    message_handler = subscribe_call_args[0][1]
+    return message_handler
 
 
 async def home_home_data_no_devices() -> HomeData:
@@ -44,21 +97,173 @@ async def mock_home_data() -> HomeData:
     return HomeData.from_dict(mock_data.HOME_DATA_RAW)
 
 
-async def test_mqtt_channel() -> None:
+async def test_mqtt_channel(mqtt_session: Mock, mqtt_channel: MqttChannel) -> None:
     """Test MQTT channel setup."""
 
-    mock_session = AsyncMock()
-
-    channel = MqttChannel(mock_session, duid="abc123", rriot=USER_DATA.rriot, mqtt_params=TEST_MQTT_PARAMS)
-
     unsub = Mock()
-    mock_session.subscribe.return_value = unsub
+    mqtt_session.subscribe.return_value = unsub
 
     callback = Mock()
-    result = await channel.subscribe(callback)
+    result = await mqtt_channel.subscribe(callback)
 
-    assert mock_session.subscribe.called
-    assert mock_session.subscribe.call_args[0][0] == "rr/m/o/user123/username/abc123"
-    assert mock_session.subscribe.call_args[0][1] == callback
+    assert mqtt_session.subscribe.called
+    assert mqtt_session.subscribe.call_args[0][0] == "rr/m/o/user123/username/abc123"
 
     assert result == unsub
+
+
+async def test_send_command_success(
+    mqtt_session: Mock,
+    mqtt_channel: MqttChannel,
+    mqtt_message_handler: Callable[[bytes], None],
+) -> None:
+    """Test successful RPC command sending and response handling."""
+    # Send a test request. We use a task so we can simulate receiving the response
+    # while the command is still being processed.
+    command_task = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST))
+    await asyncio.sleep(0.01)  # yield
+
+    # Simulate receiving the response message via MQTT
+    mqtt_message_handler(ENCODER(TEST_RESPONSE))
+    await asyncio.sleep(0.01)  # yield
+
+    # Get the result
+    result = await command_task
+
+    # Verify the command was sent
+    assert mqtt_session.publish.called
+    assert mqtt_session.publish.call_args[0][0] == "rr/m/i/user123/username/abc123"
+    raw_sent_msg = mqtt_session.publish.call_args[0][1]  # == b"encoded_message"
+    decoded_message = next(iter(DECODER(raw_sent_msg)))
+    assert decoded_message == TEST_REQUEST
+    assert decoded_message.protocol == RoborockMessageProtocol.RPC_REQUEST
+    assert decoded_message.get_request_id() == 12345
+
+    # Verify we got the response message back
+    assert result == TEST_RESPONSE
+
+
+async def test_send_command_without_request_id(
+    mqtt_session: Mock, mqtt_channel: MqttChannel, mqtt_message_handler: Callable[[bytes], None],
+) -> None:
+    """Test sending command without request ID raises exception."""
+    # Create a message without request ID
+    test_message = RoborockMessage(
+        protocol=RoborockMessageProtocol.RPC_REQUEST,
+        payload=b"no_request_id",
+    )
+
+    with pytest.raises(RoborockException, match="Message must have a request_id"):
+        await mqtt_channel.send_command(test_message)
+
+
+async def test_handle_messages_no_waiting_handler(
+    mqtt_session: Mock,
+    mqtt_channel: MqttChannel,
+    mqtt_message_handler: Callable[[bytes], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling messages when no handler is waiting."""
+    # Simulate receiving the response message via MQTT
+    mqtt_message_handler(ENCODER(TEST_REQUEST))
+    await asyncio.sleep(0.01)  # yield
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "Received message with no waiting handler: request_id=12345" in caplog.records[0].message
+
+
+async def test_concurrent_commands(
+    mqtt_session: Mock,
+    mqtt_channel: MqttChannel,
+    mqtt_message_handler: Callable[[bytes], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling multiple concurrent RPC commands."""
+
+    # Create multiple test messages with different request IDs
+    # Start both commands concurrently
+    task1 = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
+    task2 = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST2, timeout=5.0))
+    await asyncio.sleep(0.01)  # yield
+
+    # Create responses for both
+    mqtt_message_handler(ENCODER(TEST_RESPONSE))
+    await asyncio.sleep(0.01)  # yield
+
+    mqtt_message_handler(ENCODER(TEST_RESPONSE2))
+    await asyncio.sleep(0.01)  # yield
+
+    # Both should complete successfully
+    result1 = await task1
+    result2 = await task2
+
+    assert result1 == TEST_RESPONSE
+    assert result2 == TEST_RESPONSE2
+
+    assert not caplog.records
+
+
+async def test_handle_completed_future(
+    mqtt_session: Mock,
+    mqtt_channel: MqttChannel,
+    mqtt_message_handler: Callable[[bytes], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling response for an already completed future."""
+    # Send request
+    task = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
+    await asyncio.sleep(0.01)  # yield
+
+    # Send the response twice
+    mqtt_message_handler(ENCODER(TEST_RESPONSE))
+    await asyncio.sleep(0.01)  # yield
+    mqtt_message_handler(ENCODER(TEST_RESPONSE))
+    await asyncio.sleep(0.01)  # yield
+
+    # Task completes and second message is dropped with a warning
+    result = await task
+    assert result == TEST_RESPONSE
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "Received message with no waiting handler: request_id=12345" in caplog.records[0].message
+
+
+async def test_subscribe_callback_with_rpc_response(
+    mqtt_session: Mock,
+    mqtt_channel: MqttChannel,
+    received_messages: list[RoborockMessage],
+    mqtt_message_handler: Callable[[bytes], None],
+) -> None:
+    """Test that subscribe callback is called along with RPC handling."""
+    # Send request
+    task = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
+    await asyncio.sleep(0.01)  # yield
+
+    assert not received_messages
+
+    # Send the response
+    mqtt_message_handler(ENCODER(TEST_RESPONSE))
+    await asyncio.sleep(0.01)  # yield
+
+    # Task completes and second message is dropped with a warning
+    result = await task
+    assert result == TEST_RESPONSE
+
+    # The subscribe callback should have been called with the same response
+    assert len(received_messages) == 1
+    assert received_messages[0] == TEST_RESPONSE
+
+
+async def test_message_decode_error(
+    mqtt_message_handler: Callable[[bytes], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test an error during message decoding."""
+    mqtt_message_handler(b"invalid_payload")
+    await asyncio.sleep(0.01)  # yield
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "Failed to decode MQTT message" in caplog.records[0].message

--- a/tests/devices/test_mqtt_channel.py
+++ b/tests/devices/test_mqtt_channel.py
@@ -1,0 +1,64 @@
+"""Tests for the MqttChannel class."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from roborock.containers import HomeData, UserData
+from roborock.devices.mqtt_channel import MqttChannel
+from roborock.mqtt.session import MqttParams
+
+from .. import mock_data
+
+USER_DATA = UserData.from_dict(mock_data.USER_DATA)
+TEST_MQTT_PARAMS = MqttParams(
+    host="localhost",
+    port=1883,
+    tls=False,
+    username="username",
+    password="password",
+    timeout=10.0,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_mqtt_session() -> Generator[None, None, None]:
+    """Fixture to set up the MQTT session for the tests."""
+    with patch("roborock.devices.device_manager.create_mqtt_session"):
+        yield
+
+
+async def home_home_data_no_devices() -> HomeData:
+    """Mock home data API that returns no devices."""
+    return HomeData(
+        id=1,
+        name="Test Home",
+        devices=[],
+        products=[],
+    )
+
+
+async def mock_home_data() -> HomeData:
+    """Mock home data API that returns devices."""
+    return HomeData.from_dict(mock_data.HOME_DATA_RAW)
+
+
+async def test_mqtt_channel() -> None:
+    """Test MQTT channel setup."""
+
+    mock_session = AsyncMock()
+
+    channel = MqttChannel(mock_session, duid="abc123", rriot=USER_DATA.rriot, mqtt_params=TEST_MQTT_PARAMS)
+
+    unsub = Mock()
+    mock_session.subscribe.return_value = unsub
+
+    callback = Mock()
+    result = await channel.subscribe(callback)
+
+    assert mock_session.subscribe.called
+    assert mock_session.subscribe.call_args[0][0] == "rr/m/o/user123/username/abc123"
+    assert mock_session.subscribe.call_args[0][1] == callback
+
+    assert result == unsub


### PR DESCRIPTION
Update the device manager and device to establish an Mqtt "channel" which is the device-specific subscription in the mqtt session. The channel will be used for decoding messages and sending/receiving RPCs.

Lots of future work needed here including:
- Handle non-mqtt devices
- Add message decoding 
- Add message encoding and receiving of RPCs
- Local connections