### PR TITLE
feat: Add a v1 protocol channel that can send messages across MQTT or Local connections, preferring local

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -224,14 +224,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
+    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
 ]
 
 [package.dependencies]

--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -115,7 +115,16 @@ async def session(ctx, duration: int):
     devices = await device_manager.get_devices()
     click.echo(f"Discovered devices: {', '.join([device.name for device in devices])}")
 
-    click.echo("MQTT session started. Listening for messages...")
+    click.echo("MQTT session started. Querying devices...")
+    for device in devices:
+        try:
+            status = await device.get_status()
+        except RoborockException as e:
+            click.echo(f"Failed to get status for {device.name}: {e}")
+        else:
+            click.echo(f"Device {device.name} status: {status.as_dict()}")
+
+    click.echo("Listening for messages.")
     await asyncio.sleep(duration)
 
     # Close the device manager (this will close all devices and MQTT session)

--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -10,13 +10,13 @@ from roborock.containers import (
     HomeDataProduct,
     UserData,
 )
-from roborock.devices.device import RoborockDevice
+from roborock.devices.device import DeviceVersion, RoborockDevice
 from roborock.mqtt.roborock_session import create_mqtt_session
 from roborock.mqtt.session import MqttSession
 from roborock.protocol import create_mqtt_params
 from roborock.web_api import RoborockApiClient
 
-from .mqtt_channel import MqttChannel
+from .v1_channel import create_v1_channel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,8 +114,16 @@ async def create_device_manager(user_data: UserData, home_data_api: HomeDataApi)
     mqtt_session = await create_mqtt_session(mqtt_params)
 
     def device_creator(device: HomeDataDevice, product: HomeDataProduct) -> RoborockDevice:
-        mqtt_channel = MqttChannel(mqtt_session, device.duid, device.local_key, user_data.rriot, mqtt_params)
-        return RoborockDevice(user_data, device, product, mqtt_channel)
+        # Check device version and only support V1 for now
+        if device.pv != DeviceVersion.V1.value:
+            raise NotImplementedError(
+                f"Device {device.name} has version {device.pv}, but only V1 devices "
+                f"are supported through the unified interface. Use the legacy "
+                f"RoborockMqttClientV1 or RoborockLocalClientV1 for this device."
+            )
+        # Create V1 channel that handles both MQTT and local connections
+        v1_channel = create_v1_channel(user_data, mqtt_params, mqtt_session, device)
+        return RoborockDevice(user_data, device, product, v1_channel)
 
     manager = DeviceManager(home_data_api, device_creator, mqtt_session=mqtt_session)
     await manager.discover_devices()

--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -118,8 +118,7 @@ async def create_device_manager(user_data: UserData, home_data_api: HomeDataApi)
         if device.pv != DeviceVersion.V1.value:
             raise NotImplementedError(
                 f"Device {device.name} has version {device.pv}, but only V1 devices "
-                f"are supported through the unified interface. Use the legacy "
-                f"RoborockMqttClientV1 or RoborockLocalClientV1 for this device."
+                f"are supported through the unified interface."
             )
         # Create V1 channel that handles both MQTT and local connections
         v1_channel = create_v1_channel(user_data, mqtt_params, mqtt_session, device)

--- a/roborock/devices/local_channel.py
+++ b/roborock/devices/local_channel.py
@@ -64,7 +64,7 @@ class LocalChannel:
         except OSError as e:
             raise RoborockConnectionException(f"Failed to connect to {self._host}:{_PORT}") from e
 
-    async def close(self) -> None:
+    def close(self) -> None:
         """Disconnect from the device."""
         if self._transport:
             self._transport.close()
@@ -144,3 +144,25 @@ class LocalChannel:
             async with self._queue_lock:
                 self._waiting_queue.pop(request_id, None)
             raise
+
+
+# This module provides a factory function to create LocalChannel instances.
+#
+# TODO: Make a separate LocalSession and use it to manage retries with the host,
+# similar to how MqttSession works. For now this is a simple factory function
+# for creating channels.
+LocalSession = Callable[[str], LocalChannel]
+
+
+def create_local_session(local_key: str) -> LocalSession:
+    """Creates a local session which can create local channels.
+
+    This plays a role similar to the MqttSession but is really just a factory
+    for creating LocalChannel instances with the same local key.
+    """
+
+    def create_local_channel(host: str) -> LocalChannel:
+        """Create a LocalChannel instance for the given host."""
+        return LocalChannel(host, local_key)
+
+    return create_local_channel

--- a/roborock/devices/v1_channel.py
+++ b/roborock/devices/v1_channel.py
@@ -148,16 +148,12 @@ class V1Channel:
     ) -> _T:
         """Send a command using the best available transport.
 
-        Will try local connection first if available and preferred,
-        falling back to MQTT if needed.
+        Will prefer local connection if available, falling back to MQTT.
         """
-        _LOGGER.debug("Sending command: %s, params=%s", method, params)
+        connection = "local" if self.is_local_connected else "mqtt"
+        _LOGGER.debug("Sending command (%s): %s, params=%s", connection, method, params)
         if self._local_channel:
-            try:
-                return await self._send_local_decoded_command(method, response_type=response_type, params=params)
-            except RoborockException as e:
-                _LOGGER.info("Local command failed, falling back to MQTT: %s", e)
-
+            return await self._send_local_decoded_command(method, response_type=response_type, params=params)
         return await self._send_mqtt_decoded_command(method, response_type=response_type, params=params)
 
     async def _send_mqtt_raw_command(self, method: CommandType, params: ParamsType | None = None) -> dict[str, Any]:

--- a/roborock/devices/v1_channel.py
+++ b/roborock/devices/v1_channel.py
@@ -80,7 +80,9 @@ class V1Channel:
         """Subscribe to all messages from the device.
 
         This will establish MQTT connection first, and also attempt to set up
-        local connection if possible.
+        local connection if possible. Any failures to subscribe to MQTT will raise
+        a RoborockException. A local connection failure will not raise an exception,
+        since the local connection is optional.
         """
 
         if self._mqtt_unsub:

--- a/roborock/devices/v1_channel.py
+++ b/roborock/devices/v1_channel.py
@@ -1,0 +1,215 @@
+"""V1 Channel for Roborock devices.
+
+This module provides a unified channel interface for V1 protocol devices,
+handling both MQTT and local connections with automatic fallback.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from roborock.containers import HomeDataDevice, NetworkInfo, RoborockBase, UserData
+from roborock.exceptions import RoborockException
+from roborock.mqtt.session import MqttParams, MqttSession
+from roborock.protocols.v1_protocol import (
+    CommandType,
+    ParamsType,
+    SecurityData,
+    create_mqtt_payload_encoder,
+    create_security_data,
+    decode_rpc_response,
+    encode_local_payload,
+)
+from roborock.roborock_message import RoborockMessage
+from roborock.roborock_typing import RoborockCommand
+
+from .local_channel import LocalChannel, LocalSession, create_local_session
+from .mqtt_channel import MqttChannel
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "V1Channel",
+]
+
+_T = TypeVar("_T", bound=RoborockBase)
+
+
+class V1Channel:
+    """Unified V1 protocol channel with automatic MQTT/local connection handling.
+
+    This channel abstracts away the complexity of choosing between MQTT and local
+    connections, and provides high-level V1 protocol methods. It automatically
+    handles connection setup, fallback logic, and protocol encoding/decoding.
+    """
+
+    def __init__(
+        self,
+        device_uid: str,
+        security_data: SecurityData,
+        mqtt_channel: MqttChannel,
+        local_session: LocalSession,
+    ) -> None:
+        """Initialize the V1Channel.
+
+        Args:
+            mqtt_channel: MQTT channel for cloud communication
+            local_session: Factory that creates LocalChannels for a hostname.
+        """
+        self._device_uid = device_uid
+        self._mqtt_channel = mqtt_channel
+        self._mqtt_payload_encoder = create_mqtt_payload_encoder(security_data)
+        self._local_session = local_session
+        self._local_channel: LocalChannel | None = None
+        self._mqtt_unsub: Callable[[], None] | None = None
+        self._local_unsub: Callable[[], None] | None = None
+        self._callback: Callable[[RoborockMessage], None] | None = None
+        self._networking_info: NetworkInfo | None = None
+
+    @property
+    def is_local_connected(self) -> bool:
+        """Return whether local connection is available."""
+        return self._local_unsub is not None
+
+    @property
+    def is_mqtt_connected(self) -> bool:
+        """Return whether MQTT connection is available."""
+        return self._mqtt_unsub is not None
+
+    async def subscribe(self, callback: Callable[[RoborockMessage], None]) -> Callable[[], None]:
+        """Subscribe to all messages from the device.
+
+        This will establish MQTT connection first, and also attempt to set up
+        local connection if possible.
+        """
+
+        if self._mqtt_unsub:
+            raise ValueError("Already connected to the device")
+        self._callback = callback
+
+        # First establish MQTT connection
+        self._mqtt_unsub = await self._mqtt_channel.subscribe(self._on_mqtt_message)
+        _LOGGER.debug("V1Channel connected to device %s via MQTT", self._device_uid)
+
+        # Try to establish an optional local connection as well.
+        try:
+            self._local_unsub = await self._local_connect()
+        except RoborockException as err:
+            _LOGGER.warning("Could not establish local connection for device %s: %s", self._device_uid, err)
+        else:
+            _LOGGER.debug("Local connection established for device %s", self._device_uid)
+
+        def unsub() -> None:
+            """Unsubscribe from all messages."""
+            if self._mqtt_unsub:
+                self._mqtt_unsub()
+                self._mqtt_unsub = None
+            if self._local_unsub:
+                self._local_unsub()
+                self._local_unsub = None
+            _LOGGER.debug("Unsubscribed from device %s", self._device_uid)
+
+        return unsub
+
+    async def _get_networking_info(self) -> NetworkInfo:
+        """Retrieve networking information for the device.
+
+        This is a cloud only command used to get the local device's IP address.
+        """
+        try:
+            return await self._send_mqtt_decoded_command(RoborockCommand.GET_NETWORK_INFO, response_type=NetworkInfo)
+        except RoborockException as e:
+            raise RoborockException(f"Network info failed for device {self._device_uid}") from e
+
+    async def _local_connect(self) -> Callable[[], None]:
+        """Set up local connection if possible."""
+        _LOGGER.debug("Attempting to connect to local channel for device %s", self._device_uid)
+        if self._networking_info is None:
+            self._networking_info = await self._get_networking_info()
+        host = self._networking_info.ip
+        _LOGGER.debug("Connecting to local channel at %s", host)
+        self._local_channel = self._local_session(host)
+        try:
+            await self._local_channel.connect()
+        except RoborockException as e:
+            self._local_channel = None
+            raise RoborockException(f"Error connecting to local device {self._device_uid}: {e}") from e
+
+        return await self._local_channel.subscribe(self._on_local_message)
+
+    async def send_decoded_command(
+        self,
+        method: CommandType,
+        *,
+        response_type: type[_T],
+        params: ParamsType = None,
+    ) -> _T:
+        """Send a command using the best available transport.
+
+        Will try local connection first if available and preferred,
+        falling back to MQTT if needed.
+        """
+        _LOGGER.debug("Sending command: %s, params=%s", method, params)
+        if self._local_channel:
+            try:
+                return await self._send_local_decoded_command(method, response_type=response_type, params=params)
+            except RoborockException as e:
+                _LOGGER.info("Local command failed, falling back to MQTT: %s", e)
+
+        return await self._send_mqtt_decoded_command(method, response_type=response_type, params=params)
+
+    async def _send_mqtt_raw_command(self, method: CommandType, params: ParamsType | None = None) -> dict[str, Any]:
+        """Send a raw command without response handling."""
+        message = self._mqtt_payload_encoder(method, params)
+        _LOGGER.debug("Sending MQTT message for device %s: %s", self._device_uid, message)
+        _LOGGER.debug("Channel=%s", self._mqtt_channel)
+        response = await self._mqtt_channel.send_command(message)
+        return decode_rpc_response(response)
+
+    async def _send_mqtt_decoded_command(
+        self, method: CommandType, *, response_type: type[_T], params: ParamsType | None = None
+    ) -> _T:
+        """Send a command over MQTT and decode the response."""
+        decoded_response = await self._send_mqtt_raw_command(method, params)
+        return response_type.from_dict(decoded_response)
+
+    async def _send_local_raw_command(self, method: CommandType, params: ParamsType | None = None) -> dict[str, Any]:
+        """Send a raw command over local connection."""
+        if not self._local_channel:
+            raise RoborockException("Local channel is not connected")
+
+        message = encode_local_payload(method, params)
+        _LOGGER.debug("Sending local message for device %s: %s", self._device_uid, message)
+        response = await self._local_channel.send_command(message)
+        return decode_rpc_response(response)
+
+    async def _send_local_decoded_command(
+        self, method: CommandType, *, response_type: type[_T], params: ParamsType | None = None
+    ) -> _T:
+        """Send a command over local connection and decode the response."""
+        if not self._local_channel:
+            raise RoborockException("Local channel is not connected")
+        decoded_response = await self._send_local_raw_command(method, params)
+        return response_type.from_dict(decoded_response)
+
+    def _on_mqtt_message(self, message: RoborockMessage) -> None:
+        """Handle incoming MQTT messages."""
+        _LOGGER.debug("V1Channel received MQTT message from device %s: %s", self._device_uid, message)
+        if self._callback:
+            self._callback(message)
+
+    def _on_local_message(self, message: RoborockMessage) -> None:
+        """Handle incoming local messages."""
+        _LOGGER.debug("V1Channel received local message from device %s: %s", self._device_uid, message)
+        if self._callback:
+            self._callback(message)
+
+
+def create_v1_channel(
+    user_data: UserData, mqtt_params: MqttParams, mqtt_session: MqttSession, device: HomeDataDevice
+) -> V1Channel:
+    """Create a V1Channel for the given device."""
+    security_data = create_security_data(user_data.rriot)
+    mqtt_channel = MqttChannel(mqtt_session, device.duid, device.local_key, user_data.rriot, mqtt_params)
+    local_session = create_local_session(device.local_key)
+    return V1Channel(device.duid, security_data, mqtt_channel, local_session=local_session)

--- a/roborock/devices/v1_channel.py
+++ b/roborock/devices/v1_channel.py
@@ -157,10 +157,9 @@ class V1Channel:
         return await self._send_mqtt_decoded_command(method, response_type=response_type, params=params)
 
     async def _send_mqtt_raw_command(self, method: CommandType, params: ParamsType | None = None) -> dict[str, Any]:
-        """Send a raw command without response handling."""
+        """Send a raw command and return a raw unparsed response."""
         message = self._mqtt_payload_encoder(method, params)
         _LOGGER.debug("Sending MQTT message for device %s: %s", self._device_uid, message)
-        _LOGGER.debug("Channel=%s", self._mqtt_channel)
         response = await self._mqtt_channel.send_command(message)
         return decode_rpc_response(response)
 

--- a/roborock/protocols/v1_protocol.py
+++ b/roborock/protocols/v1_protocol.py
@@ -120,7 +120,7 @@ def decode_rpc_response(message: RoborockMessage) -> dict[str, Any]:
         raise RoborockException("Invalid V1 message format: missing payload")
     try:
         payload = json.loads(message.payload.decode())
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, TypeError) as e:
         raise RoborockException(f"Invalid V1 message payload: {e} for {message.payload!r}") from e
 
     _LOGGER.debug("Decoded V1 message payload: %s", payload)

--- a/roborock/protocols/v1_protocol.py
+++ b/roborock/protocols/v1_protocol.py
@@ -2,16 +2,32 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import logging
 import math
+import secrets
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from roborock.containers import RRiot
+from roborock.exceptions import RoborockException
+from roborock.protocol import Utils
 from roborock.roborock_message import MessageRetry, RoborockMessage, RoborockMessageProtocol
 from roborock.roborock_typing import RoborockCommand
 from roborock.util import get_next_int
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "SecurityData",
+    "create_security_data",
+    "create_mqtt_payload_encoder",
+    "encode_local_payload",
+    "decode_rpc_response",
+]
 
 CommandType = RoborockCommand | str
 ParamsType = list | dict | int | None
@@ -27,6 +43,13 @@ class SecurityData:
     def to_dict(self) -> dict[str, Any]:
         """Convert security data to a dictionary for sending in the payload."""
         return {"security": {"endpoint": self.endpoint, "nonce": self.nonce.hex().lower()}}
+
+
+def create_security_data(rriot: RRiot) -> SecurityData:
+    """Create a SecurityData instance for the given endpoint and nonce."""
+    nonce = secrets.token_bytes(16)
+    endpoint = base64.b64encode(Utils.md5(rriot.k.encode())[8:14]).decode()
+    return SecurityData(endpoint=endpoint, nonce=nonce)
 
 
 @dataclass
@@ -89,3 +112,38 @@ def encode_local_payload(method: CommandType, params: ParamsType) -> RoborockMes
         payload=payload,
         message_retry=message_retry,
     )
+
+
+def decode_rpc_response(message: RoborockMessage) -> dict[str, Any]:
+    """Decode a V1 RPC_RESPONSE message."""
+    if not message.payload:
+        raise RoborockException("Invalid V1 message format: missing payload")
+    try:
+        payload = json.loads(message.payload.decode())
+    except json.JSONDecodeError as e:
+        raise RoborockException(f"Invalid V1 message payload: {e} for {message.payload!r}") from e
+
+    _LOGGER.debug("Decoded V1 message payload: %s", payload)
+    datapoints = payload.get("dps", {})
+    if not isinstance(datapoints, dict):
+        raise RoborockException(f"Invalid V1 message format: 'dps' should be a dictionary for {message.payload!r}")
+
+    if not (data_point := datapoints.get("102")):
+        raise RoborockException("Invalid V1 message format: missing '102' data point")
+
+    try:
+        data_point_response = json.loads(data_point)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise RoborockException(f"Invalid V1 message data point '102': {e} for {message.payload!r}") from e
+
+    if error := data_point_response.get("error"):
+        raise RoborockException(f"Error in message: {error}")
+
+    if not (result := data_point_response.get("result")):
+        raise RoborockException(f"Invalid V1 message format: missing 'result' in data point for {message.payload!r}")
+    _LOGGER.debug("Decoded V1 message result: %s", result)
+    if isinstance(result, list) and result:
+        result = result[0]
+    if not isinstance(result, dict):
+        raise RoborockException(f"Invalid V1 message format: 'result' should be a dictionary for {message.payload!r}")
+    return result

--- a/tests/devices/test_device_manager.py
+++ b/tests/devices/test_device_manager.py
@@ -1,7 +1,7 @@
 """Tests for the DeviceManager class."""
 
 from collections.abc import Generator
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -13,15 +13,24 @@ from roborock.exceptions import RoborockException
 from .. import mock_data
 
 USER_DATA = UserData.from_dict(mock_data.USER_DATA)
+NETWORK_INFO = mock_data.NETWORK_INFO
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, name="mqtt_session")
 def setup_mqtt_session() -> Generator[Mock, None, None]:
     """Fixture to set up the MQTT session for the tests."""
     with patch("roborock.devices.device_manager.create_mqtt_session") as mock_create_session:
-        mock_unsub = Mock()
-        mock_create_session.return_value.subscribe.return_value = mock_unsub
         yield mock_create_session
+
+
+@pytest.fixture(autouse=True)
+def channel_fixture() -> Generator[Mock, None, None]:
+    """Fixture to set up the local session for the tests."""
+    with patch("roborock.devices.device_manager.create_v1_channel") as mock_channel:
+        mock_unsub = Mock()
+        mock_channel.return_value.subscribe = AsyncMock()
+        mock_channel.return_value.subscribe.return_value = mock_unsub
+        yield mock_channel
 
 
 async def home_home_data_no_devices() -> HomeData:

--- a/tests/devices/test_local_channel.py
+++ b/tests/devices/test_local_channel.py
@@ -104,7 +104,7 @@ async def test_already_connected_warning(
 async def test_close_connection(local_channel: LocalChannel, mock_loop: Mock, mock_transport: Mock) -> None:
     """Test closing the connection."""
     await local_channel.connect()
-    await local_channel.close()
+    local_channel.close()
 
     mock_transport.close.assert_called_once()
     assert local_channel._is_connected is False
@@ -112,7 +112,7 @@ async def test_close_connection(local_channel: LocalChannel, mock_loop: Mock, mo
 
 async def test_close_without_connection(local_channel: LocalChannel) -> None:
     """Test closing when not connected."""
-    await local_channel.close()  # Should not raise an exception
+    local_channel.close()
     assert local_channel._is_connected is False
 
 

--- a/tests/devices/test_v1_channel.py
+++ b/tests/devices/test_v1_channel.py
@@ -1,0 +1,573 @@
+"""Tests for the V1Channel class.
+
+This test simulates communication across both the MQTT and local connections
+and failure modes, ensuring the V1Channel behaves correctly in various scenarios.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from roborock.containers import NetworkInfo, RoborockBase, UserData
+from roborock.devices.local_channel import LocalChannel, LocalSession
+from roborock.devices.mqtt_channel import MqttChannel
+from roborock.devices.v1_channel import V1Channel
+from roborock.exceptions import RoborockException
+from roborock.protocol import create_local_decoder, create_local_encoder, create_mqtt_decoder, create_mqtt_encoder
+from roborock.protocols.v1_protocol import SecurityData, encode_local_payload
+from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
+from roborock.roborock_typing import RoborockCommand
+
+from .. import mock_data
+
+USER_DATA = UserData.from_dict(mock_data.USER_DATA)
+TEST_DEVICE_UID = "abc123"
+TEST_LOCAL_KEY = "local_key"
+TEST_SECURITY_DATA = SecurityData(endpoint="test_endpoint", nonce=b"test_nonce_16byte")
+TEST_HOST = "1.1.1.1"
+
+@dataclass
+class FakeResponse(RoborockBase):
+    state: str
+
+
+# Test messages for V1 protocol
+TEST_REQUEST = RoborockMessage(
+    protocol=RoborockMessageProtocol.RPC_REQUEST,
+    payload=json.dumps({"dps": {"101": json.dumps({"id": 12345, "method": "get_status"})}}).encode(),
+)
+TEST_RESPONSE = RoborockMessage(
+    protocol=RoborockMessageProtocol.RPC_RESPONSE,
+    payload=json.dumps({"dps": {"102": json.dumps({"id": 12345, "result": {"state": "cleaning"}})}}).encode(),
+)
+TEST_NETWORK_INFO_RESPONSE = RoborockMessage(
+    protocol=RoborockMessageProtocol.RPC_RESPONSE,
+    payload=json.dumps({"dps": {"102": json.dumps({"id": 12345, "result": mock_data.NETWORK_INFO})}}).encode(),
+)
+
+TEST_NETWORKING_INFO = NetworkInfo.from_dict(mock_data.NETWORK_INFO)
+
+# Encoders/Decoders
+MQTT_ENCODER = create_mqtt_encoder(TEST_LOCAL_KEY)
+MQTT_DECODER = create_mqtt_decoder(TEST_LOCAL_KEY)
+LOCAL_ENCODER = create_local_encoder(TEST_LOCAL_KEY)
+LOCAL_DECODER = create_local_decoder(TEST_LOCAL_KEY)
+
+
+@pytest.fixture(name="mock_mqtt_channel")
+def setup_mock_mqtt_channel() -> Mock:
+    """Mock MQTT channel for testing."""
+    mock_mqtt = AsyncMock(spec=MqttChannel)
+    mock_mqtt.subscribe = AsyncMock()
+    mock_mqtt.send_command = AsyncMock()
+    return mock_mqtt
+
+
+@pytest.fixture(name="mock_local_channel")
+def setup_mock_local_channel() -> Mock:
+    """Mock Local channel for testing."""
+    mock_local = AsyncMock(spec=LocalChannel)
+    mock_local.connect = AsyncMock()
+    mock_local.subscribe = AsyncMock()
+    mock_local.send_command = AsyncMock()
+    return mock_local
+
+
+@pytest.fixture(name="mock_local_session")
+def setup_mock_local_session(mock_local_channel: Mock) -> Mock:
+    """Mock Local session factory for testing."""
+    mock_session = Mock(spec=LocalSession)
+    mock_session.return_value = mock_local_channel
+    return mock_session
+
+
+@pytest.fixture(name="v1_channel")
+def setup_v1_channel(
+    mock_mqtt_channel: Mock,
+    mock_local_session: Mock,
+) -> V1Channel:
+    """Fixture to set up the V1 channel for tests."""
+    return V1Channel(
+        device_uid=TEST_DEVICE_UID,
+        security_data=TEST_SECURITY_DATA,
+        mqtt_channel=mock_mqtt_channel,
+        local_session=mock_local_session,
+    )
+
+
+@pytest.fixture(name="warning_caplog")
+def setup_warning_caplog(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    """Fixture to capture warning messages."""
+    caplog.set_level(logging.WARNING)
+    return caplog
+
+
+async def test_v1_channel_subscribe_mqtt_only_success(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_session: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test successful subscription with MQTT only (local connection fails)."""
+    # Setup: MQTT succeeds, local fails
+    mqtt_unsub = Mock()
+    mock_mqtt_channel.subscribe.return_value = mqtt_unsub
+    mock_mqtt_channel.send_command.return_value = TEST_NETWORK_INFO_RESPONSE
+    mock_local_channel.connect.side_effect = RoborockException("Connection failed")
+
+    callback = Mock()
+    unsub = await v1_channel.subscribe(callback)
+
+    # Verify MQTT connection was established
+    mock_mqtt_channel.subscribe.assert_called_once()
+    # Check that a callback was passed to MQTT subscription
+    assert callable(mock_mqtt_channel.subscribe.call_args[0][0])
+
+    # Verify local connection was attempted but failed
+    mock_local_session.assert_called_once_with(TEST_HOST)
+    mock_local_channel.connect.assert_called_once()
+
+    # Verify properties
+    assert v1_channel.is_mqtt_connected
+    assert not v1_channel.is_local_connected
+
+    # Test unsubscribe
+    unsub()
+    mqtt_unsub.assert_called_once()
+
+
+async def test_v1_channel_subscribe_both_connections_success(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test successful subscription with both MQTT and local connections."""
+    # Setup: both succeed
+    mqtt_unsub = Mock()
+    local_unsub = Mock()
+    mock_mqtt_channel.subscribe.return_value = mqtt_unsub
+    mock_local_channel.subscribe.return_value = local_unsub
+
+    # Mock network info retrieval
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        callback = Mock()
+        unsub = await v1_channel.subscribe(callback)
+
+    # Verify both connections established
+    mock_mqtt_channel.subscribe.assert_called_once()
+    mock_local_channel.connect.assert_called_once()
+    mock_local_channel.subscribe.assert_called_once()
+
+    # Verify properties
+    assert v1_channel.is_mqtt_connected
+    assert v1_channel.is_local_connected
+
+    # Test unsubscribe cleans up both
+    unsub()
+    mqtt_unsub.assert_called_once()
+    local_unsub.assert_called_once()
+
+
+async def test_v1_channel_subscribe_already_connected_error(v1_channel: V1Channel, mock_mqtt_channel: Mock) -> None:
+    """Test error when trying to subscribe when already connected."""
+    mock_mqtt_channel.subscribe.return_value = Mock()
+
+    # First subscription succeeds
+    await v1_channel.subscribe(Mock())
+
+    # Second subscription should fail
+    with pytest.raises(ValueError, match="Already connected to the device"):
+        await v1_channel.subscribe(Mock())
+
+
+async def test_v1_channel_local_connection_warning_logged(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+    warning_caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that local connection failures are logged as warnings."""
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.connect.side_effect = RoborockException("Local connection failed")
+
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        await v1_channel.subscribe(Mock())
+
+    assert "Could not establish local connection for device abc123" in warning_caplog.text
+    assert "Local connection failed" in warning_caplog.text
+
+
+# V1Channel command sending with fallback logic tests
+
+
+async def test_v1_channel_send_decoded_command_local_preferred(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test command sending prefers local connection when available."""
+    # Setup: both connections available
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.subscribe.return_value = Mock()
+    mock_local_channel.send_command.return_value = TEST_RESPONSE
+
+    # Establish connections
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        await v1_channel.subscribe(Mock())
+
+    # Send command
+    result = await v1_channel.send_decoded_command(
+        RoborockCommand.CHANGE_SOUND_VOLUME,
+        response_type=FakeResponse,
+    )
+
+    # Verify local was used, not MQTT
+    mock_local_channel.send_command.assert_called_once()
+    mock_mqtt_channel.send_command.assert_not_called()
+    assert result.state == "cleaning"
+
+
+async def test_v1_channel_send_decoded_command_fallback_to_mqtt(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test command sending falls back to MQTT when local fails."""
+    # Setup: both connections available initially
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.subscribe.return_value = Mock()
+    mock_mqtt_channel.send_command.return_value = TEST_RESPONSE
+
+    # Establish connections
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        await v1_channel.subscribe(Mock())
+
+    # Local command fails
+    mock_local_channel.send_command.side_effect = RoborockException("Local failed")
+
+    # Send command
+    result = await v1_channel.send_decoded_command(
+        RoborockCommand.CHANGE_SOUND_VOLUME,
+        response_type=FakeResponse,
+    )
+
+    # Verify both were attempted
+    mock_local_channel.send_command.assert_called_once()
+    mock_mqtt_channel.send_command.assert_called_once()
+    assert result.state == "cleaning"
+
+
+async def test_v1_channel_send_decoded_command_mqtt_only(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test command sending works with MQTT only."""
+    # Setup: only MQTT connection
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.connect.side_effect = RoborockException("No local")
+
+    responses = [TEST_NETWORK_INFO_RESPONSE, TEST_RESPONSE]
+
+    def send_command(*args) -> RoborockMessage:
+        return responses.pop(0)
+
+    mock_mqtt_channel.send_command.side_effect = send_command
+
+    await v1_channel.subscribe(Mock())
+
+    # Send command
+    result = await v1_channel.send_decoded_command(
+        RoborockCommand.CHANGE_SOUND_VOLUME,
+        response_type=FakeResponse,
+    )
+
+    # Verify only MQTT was used
+    mock_local_channel.send_command.assert_not_called()
+    mock_mqtt_channel.send_command.assert_called_once()
+    assert result.state == "cleaning"
+
+
+async def test_v1_channel_send_decoded_command_with_params(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test command sending with parameters."""
+    # Setup: local connection only
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.subscribe.return_value = Mock()
+    mock_local_channel.send_command.return_value = TEST_RESPONSE
+
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        await v1_channel.subscribe(Mock())
+
+    # Send command with params
+    test_params = {"volume": 80}
+    result = await v1_channel.send_decoded_command(
+        RoborockCommand.CHANGE_SOUND_VOLUME,
+        response_type=FakeResponse,
+        params=test_params,
+    )
+
+    # Verify command was sent with correct params
+    mock_local_channel.send_command.assert_called_once()
+    call_args = mock_local_channel.send_command.call_args
+    assert call_args[1]["params"] == test_params
+    assert result.state == "cleaning"
+
+
+# V1Channel message handling tests
+
+
+async def test_v1_channel_subscription_receives_mqtt_messages(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test that subscribed callback receives MQTT messages."""
+    callback = Mock()
+    
+    # Setup MQTT subscription to capture the internal callback
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.connect.side_effect = RoborockException("Local failed")
+    
+    # Subscribe
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        await v1_channel.subscribe(callback)
+    
+    # Get the MQTT callback that was registered
+    mqtt_callback = mock_mqtt_channel.subscribe.call_args[0][0]
+    
+    # Simulate MQTT message
+    test_message = TEST_RESPONSE
+    mqtt_callback(test_message)
+    
+    # Verify user callback was called
+    callback.assert_called_once_with(test_message)
+
+
+async def test_v1_channel_subscription_receives_local_messages(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test that subscribed callback receives local messages."""
+    callback = Mock()
+    
+    # Setup both connections
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.subscribe.return_value = Mock()
+    
+    # Subscribe
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        await v1_channel.subscribe(callback)
+    
+    # Get the local callback that was registered
+    local_callback = mock_local_channel.subscribe.call_args[0][0]
+    
+    # Simulate local message
+    test_message = TEST_RESPONSE
+    local_callback(test_message)
+    
+    # Verify user callback was called
+    callback.assert_called_once_with(test_message)
+
+
+# V1Channel networking tests
+
+
+async def test_v1_channel_networking_info_retrieved_during_connection(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+    mock_local_session: Mock,
+) -> None:
+    """Test that networking information is retrieved during local connection setup."""
+    # Setup: MQTT returns network info when requested
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_mqtt_channel.send_command.return_value = RoborockMessage(
+        protocol=RoborockMessageProtocol.RPC_RESPONSE,
+        payload=json.dumps({"dps": {"102": json.dumps({"id": 12345, "result": mock_data.NETWORK_INFO})}}).encode(),
+    )
+    mock_local_channel.subscribe.return_value = Mock()
+
+    # Subscribe - this should trigger network info retrieval for local connection
+    await v1_channel.subscribe(Mock())
+
+    # Verify both connections are established
+    assert v1_channel.is_mqtt_connected
+    assert v1_channel.is_local_connected
+    
+    # Verify network info was requested via MQTT
+    mock_mqtt_channel.send_command.assert_called_once()
+    
+    # Verify local session was created with the correct IP
+    mock_local_session.assert_called_once_with(mock_data.NETWORK_INFO["ip"])
+
+
+# V1Channel edge cases tests
+
+
+async def test_v1_channel_local_connect_network_info_failure(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+) -> None:
+    """Test local connection when network info retrieval fails."""
+    mock_mqtt_channel.send_command.side_effect = RoborockException("Network info failed")
+
+    with pytest.raises(RoborockException):
+        await v1_channel._local_connect()
+
+
+async def test_v1_channel_local_connect_connection_failure(
+    v1_channel: V1Channel,
+    mock_mqtt_channel: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test local connection when connection itself fails."""
+    # Network info succeeds but connection fails
+    mock_mqtt_channel.send_command.return_value = RoborockMessage(
+        protocol=RoborockMessageProtocol.RPC_RESPONSE,
+        payload=json.dumps({"dps": {"102": json.dumps({"id": 12345, "result": mock_data.NETWORK_INFO})}}).encode(),
+    )
+    mock_local_channel.connect.side_effect = RoborockException("Connection failed")
+
+    with pytest.raises(RoborockException):
+        await v1_channel._local_connect()
+
+
+async def test_v1_channel_command_encoding_validation(v1_channel: V1Channel) -> None:
+    """Test that command encoding works for different protocols."""
+    # Test MQTT encoding
+    mqtt_message = v1_channel._mqtt_payload_encoder(RoborockCommand.CHANGE_SOUND_VOLUME, {"volume": 50})
+
+    # Test local encoding
+    local_message = encode_local_payload(RoborockCommand.CHANGE_SOUND_VOLUME, {"volume": 50})
+
+    # Verify both are RoborockMessage instances
+    assert isinstance(mqtt_message, RoborockMessage)
+    assert isinstance(local_message, RoborockMessage)
+
+    # But they should have different protocols
+    assert mqtt_message.protocol == RoborockMessageProtocol.RPC_REQUEST
+    assert local_message.protocol == RoborockMessageProtocol.GENERAL_REQUEST
+
+
+async def test_v1_channel_connection_state_properties(v1_channel: V1Channel) -> None:
+    """Test connection state properties work correctly."""
+    # Initially not connected
+    assert not v1_channel.is_mqtt_connected
+    assert not v1_channel.is_local_connected
+
+    # Set up MQTT connection
+    v1_channel._mqtt_unsub = Mock()
+    assert v1_channel.is_mqtt_connected
+    assert not v1_channel.is_local_connected
+
+    # Set up local connection
+    v1_channel._local_unsub = Mock()
+    assert v1_channel.is_mqtt_connected
+    assert v1_channel.is_local_connected
+
+    # Clear connections
+    v1_channel._mqtt_unsub = None
+    v1_channel._local_unsub = None
+    assert not v1_channel.is_mqtt_connected
+    assert not v1_channel.is_local_connected
+
+
+# V1Channel integration tests
+
+
+async def test_v1_channel_full_subscribe_and_command_flow(
+    mock_mqtt_channel: Mock,
+    mock_local_session: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test the complete flow from subscription to command execution."""
+    # Setup: successful connections and responses
+    mqtt_unsub = Mock()
+    local_unsub = Mock()
+    mock_mqtt_channel.subscribe.return_value = mqtt_unsub
+    mock_local_channel.subscribe.return_value = local_unsub
+    mock_local_channel.send_command.return_value = TEST_RESPONSE
+
+    # Create V1Channel and subscribe
+    v1_channel = V1Channel(
+        device_uid=TEST_DEVICE_UID,
+        security_data=TEST_SECURITY_DATA,
+        mqtt_channel=mock_mqtt_channel,
+        local_session=mock_local_session,
+    )
+
+    # Mock network info for local connection
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        callback = Mock()
+        unsub = await v1_channel.subscribe(callback)
+
+    # Verify both connections established
+    assert v1_channel.is_mqtt_connected
+    assert v1_channel.is_local_connected
+
+    # Send a command (should use local)
+    result = await v1_channel.send_decoded_command(
+        RoborockCommand.GET_STATUS,
+        response_type=FakeResponse,
+    )
+
+    # Verify command was sent via local connection
+    mock_local_channel.send_command.assert_called_once()
+    mock_mqtt_channel.send_command.assert_not_called()
+    assert result.state == "cleaning"
+
+    # Test message callback
+    test_message = TEST_RESPONSE
+    v1_channel._callback = callback
+    v1_channel._on_local_message(test_message)
+    callback.assert_called_with(test_message)
+
+    # Clean up
+    unsub()
+    mqtt_unsub.assert_called_once()
+    local_unsub.assert_called_once()
+
+
+async def test_v1_channel_graceful_degradation_local_to_mqtt(
+    mock_mqtt_channel: Mock,
+    mock_local_session: Mock,
+    mock_local_channel: Mock,
+) -> None:
+    """Test graceful degradation from local to MQTT during operation."""
+    # Setup: both connections succeed initially
+    mock_mqtt_channel.subscribe.return_value = Mock()
+    mock_local_channel.subscribe.return_value = Mock()
+
+    v1_channel = V1Channel(
+        device_uid=TEST_DEVICE_UID,
+        security_data=TEST_SECURITY_DATA,
+        mqtt_channel=mock_mqtt_channel,
+        local_session=mock_local_session,
+    )
+
+    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
+        await v1_channel.subscribe(Mock())
+
+    # First command: local works
+    mock_local_channel.send_command.return_value = TEST_RESPONSE
+    result1 = await v1_channel.send_decoded_command(RoborockCommand.GET_STATUS, response_type=FakeResponse)
+    assert result1.state == "cleaning"
+    mock_local_channel.send_command.assert_called_once()
+
+    # Second command: local fails, falls back to MQTT
+    mock_local_channel.send_command.side_effect = RoborockException("Local failed")
+    mock_mqtt_channel.send_command.return_value = TEST_RESPONSE
+    result2 = await v1_channel.send_decoded_command(RoborockCommand.GET_STATUS, response_type=FakeResponse)
+    assert result2.state == "cleaning"
+
+    # Verify both were attempted
+    assert mock_local_channel.send_command.call_count == 2
+    mock_mqtt_channel.send_command.assert_called_once()

--- a/tests/devices/test_v1_channel.py
+++ b/tests/devices/test_v1_channel.py
@@ -29,6 +29,7 @@ TEST_LOCAL_KEY = "local_key"
 TEST_SECURITY_DATA = SecurityData(endpoint="test_endpoint", nonce=b"test_nonce_16byte")
 TEST_HOST = "1.1.1.1"
 
+
 @dataclass
 class FakeResponse(RoborockBase):
     state: str
@@ -330,22 +331,22 @@ async def test_v1_channel_subscription_receives_mqtt_messages(
 ) -> None:
     """Test that subscribed callback receives MQTT messages."""
     callback = Mock()
-    
+
     # Setup MQTT subscription to capture the internal callback
     mock_mqtt_channel.subscribe.return_value = Mock()
     mock_local_channel.connect.side_effect = RoborockException("Local failed")
-    
+
     # Subscribe
     with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
         await v1_channel.subscribe(callback)
-    
+
     # Get the MQTT callback that was registered
     mqtt_callback = mock_mqtt_channel.subscribe.call_args[0][0]
-    
+
     # Simulate MQTT message
     test_message = TEST_RESPONSE
     mqtt_callback(test_message)
-    
+
     # Verify user callback was called
     callback.assert_called_once_with(test_message)
 
@@ -357,22 +358,22 @@ async def test_v1_channel_subscription_receives_local_messages(
 ) -> None:
     """Test that subscribed callback receives local messages."""
     callback = Mock()
-    
+
     # Setup both connections
     mock_mqtt_channel.subscribe.return_value = Mock()
     mock_local_channel.subscribe.return_value = Mock()
-    
+
     # Subscribe
     with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
         await v1_channel.subscribe(callback)
-    
+
     # Get the local callback that was registered
     local_callback = mock_local_channel.subscribe.call_args[0][0]
-    
+
     # Simulate local message
     test_message = TEST_RESPONSE
     local_callback(test_message)
-    
+
     # Verify user callback was called
     callback.assert_called_once_with(test_message)
 
@@ -401,10 +402,10 @@ async def test_v1_channel_networking_info_retrieved_during_connection(
     # Verify both connections are established
     assert v1_channel.is_mqtt_connected
     assert v1_channel.is_local_connected
-    
+
     # Verify network info was requested via MQTT
     mock_mqtt_channel.send_command.assert_called_once()
-    
+
     # Verify local session was created with the correct IP
     mock_local_session.assert_called_once_with(mock_data.NETWORK_INFO["ip"])
 

--- a/tests/devices/test_v1_channel.py
+++ b/tests/devices/test_v1_channel.py
@@ -6,12 +6,11 @@ and failure modes, ensuring the V1Channel behaves correctly in various scenarios
 
 import json
 import logging
-from dataclasses import dataclass
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from roborock.containers import NetworkInfo, RoborockBase, UserData, S5MaxStatus, RoborockStateCode
+from roborock.containers import NetworkInfo, RoborockStateCode, S5MaxStatus, UserData
 from roborock.devices.local_channel import LocalChannel, LocalSession
 from roborock.devices.mqtt_channel import MqttChannel
 from roborock.devices.v1_channel import V1Channel
@@ -37,7 +36,9 @@ TEST_REQUEST = RoborockMessage(
 )
 TEST_RESPONSE = RoborockMessage(
     protocol=RoborockMessageProtocol.RPC_RESPONSE,
-    payload=json.dumps({"dps": {"102": json.dumps({"id": 12345, "result": {"state": RoborockStateCode.cleaning}})}}).encode(),
+    payload=json.dumps(
+        {"dps": {"102": json.dumps({"id": 12345, "result": {"state": RoborockStateCode.cleaning}})}}
+    ).encode(),
 )
 TEST_NETWORK_INFO_RESPONSE = RoborockMessage(
     protocol=RoborockMessageProtocol.RPC_RESPONSE,
@@ -60,6 +61,19 @@ def setup_mock_mqtt_channel() -> Mock:
     mock_mqtt.subscribe = AsyncMock()
     mock_mqtt.send_command = AsyncMock()
     return mock_mqtt
+
+
+@pytest.fixture(name="mqtt_responses", autouse=True)
+def setup_mqtt_responses(mock_mqtt_channel: Mock) -> list[RoborockMessage]:
+    """Fixture to provide a list of mock MQTT responses."""
+
+    responses: list[RoborockMessage] = [TEST_NETWORK_INFO_RESPONSE]
+
+    def send_command(*args) -> RoborockMessage:
+        return responses.pop(0)
+
+    mock_mqtt_channel.send_command.side_effect = send_command
+    return responses
 
 
 @pytest.fixture(name="mock_local_channel")
@@ -148,9 +162,8 @@ async def test_v1_channel_subscribe_both_connections_success(
     mock_local_channel.subscribe.return_value = local_unsub
 
     # Mock network info retrieval
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        callback = Mock()
-        unsub = await v1_channel.subscribe(callback)
+    callback = Mock()
+    unsub = await v1_channel.subscribe(callback)
 
     # Verify both connections established
     mock_mqtt_channel.subscribe.assert_called_once()
@@ -189,8 +202,7 @@ async def test_v1_channel_local_connection_warning_logged(
     mock_mqtt_channel.subscribe.return_value = Mock()
     mock_local_channel.connect.side_effect = RoborockException("Local connection failed")
 
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        await v1_channel.subscribe(Mock())
+    await v1_channel.subscribe(Mock())
 
     assert "Could not establish local connection for device abc123" in warning_caplog.text
     assert "Local connection failed" in warning_caplog.text
@@ -205,16 +217,12 @@ async def test_v1_channel_send_decoded_command_local_preferred(
     mock_local_channel: Mock,
 ) -> None:
     """Test command sending prefers local connection when available."""
-    # Setup: both connections available
-    mock_mqtt_channel.subscribe.return_value = Mock()
-    mock_local_channel.subscribe.return_value = Mock()
-    mock_local_channel.send_command.return_value = TEST_RESPONSE
-
     # Establish connections
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        await v1_channel.subscribe(Mock())
+    await v1_channel.subscribe(Mock())
+    mock_mqtt_channel.send_command.reset_mock(return_value=False)
 
     # Send command
+    mock_local_channel.send_command.return_value = TEST_RESPONSE
     result = await v1_channel.send_decoded_command(
         RoborockCommand.CHANGE_SOUND_VOLUME,
         response_type=S5MaxStatus,
@@ -230,21 +238,19 @@ async def test_v1_channel_send_decoded_command_fallback_to_mqtt(
     v1_channel: V1Channel,
     mock_mqtt_channel: Mock,
     mock_local_channel: Mock,
+    mqtt_responses: list[RoborockMessage],
 ) -> None:
     """Test command sending falls back to MQTT when local fails."""
-    # Setup: both connections available initially
-    mock_mqtt_channel.subscribe.return_value = Mock()
-    mock_local_channel.subscribe.return_value = Mock()
-    mock_mqtt_channel.send_command.return_value = TEST_RESPONSE
 
     # Establish connections
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        await v1_channel.subscribe(Mock())
+    await v1_channel.subscribe(Mock())
+    mock_mqtt_channel.send_command.reset_mock(return_value=False)
 
     # Local command fails
     mock_local_channel.send_command.side_effect = RoborockException("Local failed")
 
     # Send command
+    mqtt_responses.append(TEST_RESPONSE)
     result = await v1_channel.send_decoded_command(
         RoborockCommand.CHANGE_SOUND_VOLUME,
         response_type=S5MaxStatus,
@@ -260,22 +266,19 @@ async def test_v1_channel_send_decoded_command_mqtt_only(
     v1_channel: V1Channel,
     mock_mqtt_channel: Mock,
     mock_local_channel: Mock,
+    mqtt_responses: list[RoborockMessage],
 ) -> None:
     """Test command sending works with MQTT only."""
     # Setup: only MQTT connection
-    mock_mqtt_channel.subscribe.return_value = Mock()
+    # mock_mqtt_channel.subscribe.return_value = Mock()
     mock_local_channel.connect.side_effect = RoborockException("No local")
 
-    responses = [TEST_NETWORK_INFO_RESPONSE, TEST_RESPONSE]
-
-    def send_command(*args) -> RoborockMessage:
-        return responses.pop(0)
-
-    mock_mqtt_channel.send_command.side_effect = send_command
-
     await v1_channel.subscribe(Mock())
+    mock_mqtt_channel.send_command.assert_called_once()  # network info
+    mock_mqtt_channel.send_command.reset_mock(return_value=False)
 
     # Send command
+    mqtt_responses.append(TEST_RESPONSE)
     result = await v1_channel.send_decoded_command(
         RoborockCommand.CHANGE_SOUND_VOLUME,
         response_type=S5MaxStatus,
@@ -293,17 +296,13 @@ async def test_v1_channel_send_decoded_command_with_params(
     mock_local_channel: Mock,
 ) -> None:
     """Test command sending with parameters."""
-    # Setup: local connection only
-    mock_mqtt_channel.subscribe.return_value = Mock()
-    mock_local_channel.subscribe.return_value = Mock()
-    mock_local_channel.send_command.return_value = TEST_RESPONSE
 
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        await v1_channel.subscribe(Mock())
+    await v1_channel.subscribe(Mock())
 
     # Send command with params
+    mock_local_channel.send_command.return_value = TEST_RESPONSE
     test_params = {"volume": 80}
-    result = await v1_channel.send_decoded_command(
+    await v1_channel.send_decoded_command(
         RoborockCommand.CHANGE_SOUND_VOLUME,
         response_type=S5MaxStatus,
         params=test_params,
@@ -312,11 +311,17 @@ async def test_v1_channel_send_decoded_command_with_params(
     # Verify command was sent with correct params
     mock_local_channel.send_command.assert_called_once()
     call_args = mock_local_channel.send_command.call_args
-    assert call_args[1]["params"] == test_params
-    assert result.state == RoborockStateCode.cleaning
-
-
-# V1Channel message handling tests
+    sent_message = call_args[0][0]
+    assert sent_message
+    assert isinstance(sent_message, RoborockMessage)
+    assert sent_message.payload
+    payload = sent_message.payload.decode()
+    json_data = json.loads(payload)
+    assert "dps" in json_data
+    assert "101" in json_data["dps"]
+    decoded_payload = json.loads(json_data["dps"]["101"])
+    assert decoded_payload["method"] == "change_sound_volume"
+    assert decoded_payload["params"] == {"volume": 80}
 
 
 async def test_v1_channel_subscription_receives_mqtt_messages(
@@ -332,8 +337,7 @@ async def test_v1_channel_subscription_receives_mqtt_messages(
     mock_local_channel.connect.side_effect = RoborockException("Local failed")
 
     # Subscribe
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        await v1_channel.subscribe(callback)
+    await v1_channel.subscribe(callback)
 
     # Get the MQTT callback that was registered
     mqtt_callback = mock_mqtt_channel.subscribe.call_args[0][0]
@@ -359,8 +363,7 @@ async def test_v1_channel_subscription_receives_local_messages(
     mock_local_channel.subscribe.return_value = Mock()
 
     # Subscribe
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        await v1_channel.subscribe(callback)
+    await v1_channel.subscribe(callback)
 
     # Get the local callback that was registered
     local_callback = mock_local_channel.subscribe.call_args[0][0]
@@ -476,13 +479,11 @@ async def test_v1_channel_connection_state_properties(v1_channel: V1Channel) -> 
     assert not v1_channel.is_local_connected
 
 
-# V1Channel integration tests
-
-
 async def test_v1_channel_full_subscribe_and_command_flow(
     mock_mqtt_channel: Mock,
     mock_local_session: Mock,
     mock_local_channel: Mock,
+    mqtt_responses: list[RoborockMessage],
 ) -> None:
     """Test the complete flow from subscription to command execution."""
     # Setup: successful connections and responses
@@ -501,9 +502,9 @@ async def test_v1_channel_full_subscribe_and_command_flow(
     )
 
     # Mock network info for local connection
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        callback = Mock()
-        unsub = await v1_channel.subscribe(callback)
+    callback = Mock()
+    unsub = await v1_channel.subscribe(callback)
+    mock_mqtt_channel.send_command.reset_mock(return_value=False)
 
     # Verify both connections established
     assert v1_channel.is_mqtt_connected
@@ -536,12 +537,9 @@ async def test_v1_channel_graceful_degradation_local_to_mqtt(
     mock_mqtt_channel: Mock,
     mock_local_session: Mock,
     mock_local_channel: Mock,
+    mqtt_responses: list[RoborockMessage],
 ) -> None:
     """Test graceful degradation from local to MQTT during operation."""
-    # Setup: both connections succeed initially
-    mock_mqtt_channel.subscribe.return_value = Mock()
-    mock_local_channel.subscribe.return_value = Mock()
-
     v1_channel = V1Channel(
         device_uid=TEST_DEVICE_UID,
         security_data=TEST_SECURITY_DATA,
@@ -549,18 +547,19 @@ async def test_v1_channel_graceful_degradation_local_to_mqtt(
         local_session=mock_local_session,
     )
 
-    with patch.object(v1_channel, "_get_networking_info", return_value=TEST_NETWORKING_INFO):
-        await v1_channel.subscribe(Mock())
+    await v1_channel.subscribe(Mock())
+    mock_mqtt_channel.send_command.reset_mock(return_value=False)
 
     # First command: local works
     mock_local_channel.send_command.return_value = TEST_RESPONSE
     result1 = await v1_channel.send_decoded_command(RoborockCommand.GET_STATUS, response_type=S5MaxStatus)
     assert result1.state == RoborockStateCode.cleaning
     mock_local_channel.send_command.assert_called_once()
+    mock_mqtt_channel.send_command.assert_not_called()
 
     # Second command: local fails, falls back to MQTT
     mock_local_channel.send_command.side_effect = RoborockException("Local failed")
-    mock_mqtt_channel.send_command.return_value = TEST_RESPONSE
+    mqtt_responses.append(TEST_RESPONSE)
     result2 = await v1_channel.send_decoded_command(RoborockCommand.GET_STATUS, response_type=S5MaxStatus)
     assert result2.state == RoborockStateCode.cleaning
 

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -773,3 +773,11 @@ GET_CODE_RESPONSE = {"code": 200, "msg": "success", "data": None}
 HASHED_USER = hashlib.md5((USER_ID + ":" + K_VALUE).encode()).hexdigest()[2:10]
 MQTT_PUBLISH_TOPIC = f"rr/m/o/{USER_ID}/{HASHED_USER}/{PRODUCT_ID}"
 TEST_LOCAL_API_HOST = "1.1.1.1"
+
+NETWORK_INFO = {
+    "ip": TEST_LOCAL_API_HOST,
+    "ssid": "test_wifi",
+    "mac": "aa:bb:cc:dd:ee:ff",
+    "bssid": "aa:bb:cc:dd:ee:ff",
+    "rssi": -50,
+}

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the protocols package."""

--- a/tests/protocols/test_v1_protocol.py
+++ b/tests/protocols/test_v1_protocol.py
@@ -1,0 +1,125 @@
+"""Tests for the v1 protocol message encoding and decoding."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from freezegun import freeze_time
+
+from roborock.containers import RoborockBase, UserData
+from roborock.protocols.v1_protocol import (
+    SecurityData,
+    create_mqtt_payload_encoder,
+    decode_rpc_response,
+    encode_local_payload,
+)
+from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
+from roborock.roborock_typing import RoborockCommand
+
+from .. import mock_data
+
+USER_DATA = UserData.from_dict(mock_data.USER_DATA)
+TEST_REQUEST_ID = 44444
+SECURITY_DATA = SecurityData(endpoint="3PBTIjvc", nonce=b"fake-nonce")
+
+
+@pytest.fixture(autouse=True)
+def fixed_time_fixture() -> Generator[None, None, None]:
+    """Fixture to freeze time for predictable request IDs."""
+    # Freeze time to a specific point so request IDs are predictable
+    with freeze_time("2025-01-20T12:00:00"):
+        yield
+
+
+@pytest.fixture(name="test_request_id", autouse=True)
+def request_id_fixture() -> Generator[int, None, None]:
+    """Fixture to provide a fixed request ID."""
+    with patch("roborock.protocols.v1_protocol.get_next_int", return_value=TEST_REQUEST_ID):
+        yield TEST_REQUEST_ID
+
+
+@pytest.mark.parametrize(
+    ("command", "params", "expected"),
+    [
+        (
+            RoborockCommand.GET_STATUS,
+            None,
+            b'{"dps":{"101":"{\\"id\\":44444,\\"method\\":\\"get_status\\",\\"params\\":[]}"},"t":1737374400}',
+        )
+    ],
+)
+def test_encode_local_payload(command, params, expected):
+    """Test encoding of local payload for V1 commands."""
+    message = encode_local_payload(command, params)
+    assert isinstance(message, RoborockMessage)
+    assert message.protocol == RoborockMessageProtocol.GENERAL_REQUEST
+    assert message.payload == expected
+
+
+@pytest.mark.parametrize(
+    ("command", "params", "expected"),
+    [
+        (
+            RoborockCommand.GET_STATUS,
+            None,
+            b'{"dps":{"101":"{\\"id\\":44444,\\"method\\":\\"get_status\\",\\"params\\":[],\\"security\\":{\\"endpoint\\":\\"3PBTIjvc\\",\\"nonce\\":\\"66616b652d6e6f6e6365\\"}}"},"t":1737374400}',
+        )
+    ],
+)
+def test_encode_mqtt_payload(command, params, expected):
+    """Test encoding of local payload for V1 commands."""
+    encoder = create_mqtt_payload_encoder(SECURITY_DATA)
+    message = encoder(command, params)
+    assert isinstance(message, RoborockMessage)
+    assert message.protocol == RoborockMessageProtocol.RPC_REQUEST
+    assert message.payload == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            b'{"t":1652547161,"dps":{"102":"{\\"id\\":20005,\\"result\\":[{\\"msg_ver\\":2,\\"msg_seq\\":1072,\\"state\\":8,\\"battery\\":100,\\"clean_time\\":1041,\\"clean_area\\":37080000,\\"error_code\\":0,\\"map_present\\":1,\\"in_cleaning\\":0,\\"in_returning\\":0,\\"in_fresh_state\\":1,\\"lab_status\\":1,\\"water_box_status\\":0,\\"fan_power\\":103,\\"dnd_enabled\\":0,\\"map_status\\":3,\\"is_locating\\":0,\\"lock_status\\":0,\\"water_box_mode\\":202,\\"distance_off\\":0,\\"water_box_carriage_status\\":0,\\"mop_forbidden_enable\\":0,\\"unsave_map_reason\\":0,\\"unsave_map_flag\\":0}]}"}}',
+            {
+                "msg_ver": 2,
+                "msg_seq": 1072,
+                "state": 8,
+                "battery": 100,
+                "clean_time": 1041,
+                "clean_area": 37080000,
+                "error_code": 0,
+                "map_present": 1,
+                "in_cleaning": 0,
+                "in_returning": 0,
+                "in_fresh_state": 1,
+                "lab_status": 1,
+                "water_box_status": 0,
+                "fan_power": 103,
+                "dnd_enabled": 0,
+                "map_status": 3,
+                "is_locating": 0,
+                "lock_status": 0,
+                "water_box_mode": 202,
+                "distance_off": 0,
+                "water_box_carriage_status": 0,
+                "mop_forbidden_enable": 0,
+                "unsave_map_reason": 0,
+                "unsave_map_flag": 0,
+            },
+        ),
+    ],
+)
+def test_decode_rpc_response(payload: bytes, expected: RoborockBase) -> None:
+    """Test decoding a v1 RPC response protocol message."""
+    # The values other than the payload are arbitrary
+    message = RoborockMessage(
+        protocol=RoborockMessageProtocol.GENERAL_RESPONSE,
+        payload=payload,
+        seq=12750,
+        version=b"1.0",
+        random=97431,
+        timestamp=1652547161,
+        message_retry=None,
+    )
+    decoded_message = decode_rpc_response(message)
+    assert decoded_message == expected


### PR DESCRIPTION
Add a V1Channel class that wraps the MQTT and Local channels and handles getting the network info from mqtt and decidign which channel is available. The local connection does not handle retries yet, which will be fixed in a follow up change.

Most of the PR is for tests exercising corner cases. This PR was heavily coded by Co-pilot.