### PR TITLE
chore: Refactor some of the internal channel details used by the device.

### DIFF
--- a/roborock/devices/device.py
+++ b/roborock/devices/device.py
@@ -117,4 +117,4 @@ class RoborockDevice:
         This is a placeholder command and will likely be changed/moved in the future.
         """
         status_type: type[Status] = ModelStatus.get(self._product_info.model, S7MaxVStatus)
-        return await self._v1_channel.send_decoded_command(RoborockCommand.GET_STATUS, response_type=status_type)
+        return await self._v1_channel.rpc_channel.send_command(RoborockCommand.GET_STATUS, response_type=status_type)

--- a/roborock/devices/local_channel.py
+++ b/roborock/devices/local_channel.py
@@ -50,6 +50,11 @@ class LocalChannel:
         self._encoder: Encoder = create_local_encoder(local_key)
         self._queue_lock = asyncio.Lock()
 
+    @property
+    def is_connected(self) -> bool:
+        """Check if the channel is currently connected."""
+        return self._is_connected
+
     async def connect(self) -> None:
         """Connect to the device."""
         if self._is_connected:
@@ -113,7 +118,7 @@ class LocalChannel:
             else:
                 _LOGGER.debug("Received message with no waiting handler: request_id=%s", request_id)
 
-    async def send_command(self, message: RoborockMessage, timeout: float = 10.0) -> RoborockMessage:
+    async def send_message(self, message: RoborockMessage, timeout: float = 10.0) -> RoborockMessage:
         """Send a command message and wait for the response message."""
         if not self._transport or not self._is_connected:
             raise RoborockConnectionException("Not connected to device")

--- a/roborock/devices/mqtt_channel.py
+++ b/roborock/devices/mqtt_channel.py
@@ -80,7 +80,7 @@ class MqttChannel:
             else:
                 _LOGGER.debug("Received message with no waiting handler: request_id=%s", request_id)
 
-    async def send_command(self, message: RoborockMessage, timeout: float = 10.0) -> RoborockMessage:
+    async def send_message(self, message: RoborockMessage, timeout: float = 10.0) -> RoborockMessage:
         """Send a command message and wait for the response message.
 
         Returns the raw response message - caller is responsible for parsing.

--- a/roborock/devices/v1_rpc_channel.py
+++ b/roborock/devices/v1_rpc_channel.py
@@ -1,0 +1,158 @@
+"""V1 Rpc Channel for Roborock devices.
+
+This is a wrapper around the V1 channel that provides a higher level interface
+for sending typed commands and receiving typed responses. This also provides
+a simple interface for sending commands and receiving responses over both MQTT
+and local connections, preferring local when available.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import Any, Protocol, TypeVar, overload
+
+from roborock.containers import RoborockBase
+from roborock.protocols.v1_protocol import (
+    CommandType,
+    ParamsType,
+    SecurityData,
+    create_mqtt_payload_encoder,
+    decode_rpc_response,
+    encode_local_payload,
+)
+from roborock.roborock_message import RoborockMessage
+
+from .local_channel import LocalChannel
+from .mqtt_channel import MqttChannel
+
+_LOGGER = logging.getLogger(__name__)
+
+
+_T = TypeVar("_T", bound=RoborockBase)
+
+
+class V1RpcChannel(Protocol):
+    """Protocol for V1 RPC channels.
+
+    This is a wrapper around a raw channel that provides a high-level interface
+    for sending commands and receiving responses.
+    """
+
+    @overload
+    async def send_command(
+        self,
+        method: CommandType,
+        *,
+        params: ParamsType = None,
+    ) -> Any:
+        """Send a command and return a decoded response."""
+        ...
+
+    @overload
+    async def send_command(
+        self,
+        method: CommandType,
+        *,
+        response_type: type[_T],
+        params: ParamsType = None,
+    ) -> _T:
+        """Send a command and return a parsed response RoborockBase type."""
+        ...
+
+    async def send_command(
+        self,
+        method: CommandType,
+        *,
+        response_type: type[_T] | None = None,
+        params: ParamsType = None,
+    ) -> _T | Any:
+        """Send a command and return either a decoded or parsed response."""
+        ...
+
+
+class BaseV1RpcChannel:
+    """Base implementation that provides the typed response logic."""
+
+    async def send_command(
+        self,
+        method: CommandType,
+        *,
+        response_type: type[_T] | None = None,
+        params: ParamsType = None,
+    ) -> _T | Any:
+        """Send a command and return either a decoded or parsed response."""
+        decoded_response = await self._send_raw_command(method, params=params)
+
+        if response_type is not None:
+            return response_type.from_dict(decoded_response)
+        return decoded_response
+
+    async def _send_raw_command(
+        self,
+        method: CommandType,
+        *,
+        params: ParamsType = None,
+    ) -> Any:
+        """Send a raw command and return the decoded response. Must be implemented by subclasses."""
+        raise NotImplementedError
+
+
+class CombinedChannel(BaseV1RpcChannel):
+    """A V1 RPC channel that can use both local and MQTT channels, preferring local when available."""
+
+    def __init__(
+        self, local_channel: LocalChannel, local_rpc_channel: V1RpcChannel, mqtt_channel: V1RpcChannel
+    ) -> None:
+        """Initialize the combined channel with local and MQTT channels."""
+        self._local_channel = local_channel
+        self._local_rpc_channel = local_rpc_channel
+        self._mqtt_rpc_channel = mqtt_channel
+
+    async def _send_raw_command(
+        self,
+        method: CommandType,
+        *,
+        params: ParamsType = None,
+    ) -> Any:
+        """Send a command and return a parsed response RoborockBase type."""
+        if self._local_channel.is_connected:
+            return await self._local_rpc_channel.send_command(method, params=params)
+        return await self._mqtt_rpc_channel.send_command(method, params=params)
+
+
+class PayloadEncodedV1Channel(BaseV1RpcChannel):
+    """Protocol for V1 channels that send encoded commands."""
+
+    def __init__(
+        self,
+        name: str,
+        channel: MqttChannel | LocalChannel,
+        payload_encoder: Callable[[CommandType, ParamsType], RoborockMessage],
+    ) -> None:
+        """Initialize the channel with a raw channel and an encoder function."""
+        self._name = name
+        self._channel = channel
+        self._payload_encoder = payload_encoder
+
+    async def _send_raw_command(
+        self,
+        method: CommandType,
+        *,
+        params: ParamsType = None,
+    ) -> Any:
+        """Send a command and return a parsed response RoborockBase type."""
+        _LOGGER.debug("Sending command (%s): %s, params=%s", self._name, method, params)
+        message = self._payload_encoder(method, params)
+        response = await self._channel.send_message(message)
+        return decode_rpc_response(response)
+
+
+def create_mqtt_rpc_channel(mqtt_channel: MqttChannel, security_data: SecurityData) -> V1RpcChannel:
+    """Create a V1 RPC channel using an MQTT channel."""
+    payload_encoder = create_mqtt_payload_encoder(security_data)
+    return PayloadEncodedV1Channel("mqtt", mqtt_channel, payload_encoder)
+
+
+def create_combined_rpc_channel(local_channel: LocalChannel, mqtt_rpc_channel: V1RpcChannel) -> V1RpcChannel:
+    """Create a V1 RPC channel that combines local and MQTT channels."""
+    local_rpc_channel = PayloadEncodedV1Channel("local", local_channel, encode_local_payload)
+    return CombinedChannel(local_channel, local_rpc_channel, mqtt_rpc_channel)

--- a/roborock/devices/v1_rpc_channel.py
+++ b/roborock/devices/v1_rpc_channel.py
@@ -58,18 +58,8 @@ class V1RpcChannel(Protocol):
         """Send a command and return a parsed response RoborockBase type."""
         ...
 
-    async def send_command(
-        self,
-        method: CommandType,
-        *,
-        response_type: type[_T] | None = None,
-        params: ParamsType = None,
-    ) -> _T | Any:
-        """Send a command and return either a decoded or parsed response."""
-        ...
 
-
-class BaseV1RpcChannel:
+class BaseV1RpcChannel(V1RpcChannel):
     """Base implementation that provides the typed response logic."""
 
     async def send_command(

--- a/tests/devices/test_device.py
+++ b/tests/devices/test_device.py
@@ -56,11 +56,11 @@ async def test_device_connection(device: RoborockDevice, channel: AsyncMock) -> 
 async def test_device_get_status_command(device: RoborockDevice, channel: AsyncMock) -> None:
     """Test the device get_status command."""
     # Mock response for get_status command
-    channel.send_decoded_command.return_value = STATUS
+    channel.rpc_channel.send_command.return_value = STATUS
 
     # Test get_status and verify the command was sent
     status = await device.get_status()
-    assert channel.send_decoded_command.called
+    assert channel.rpc_channel.send_command.called
 
     # Verify the result
     assert status is not None

--- a/tests/devices/test_mqtt_channel.py
+++ b/tests/devices/test_mqtt_channel.py
@@ -122,7 +122,7 @@ async def test_mqtt_channel(mqtt_session: Mock, mqtt_channel: MqttChannel) -> No
     assert result == unsub
 
 
-async def test_send_command_success(
+async def test_send_message_success(
     mqtt_session: Mock,
     mqtt_channel: MqttChannel,
     mqtt_message_handler: Callable[[bytes], None],
@@ -130,7 +130,7 @@ async def test_send_command_success(
     """Test successful RPC command sending and response handling."""
     # Send a test request. We use a task so we can simulate receiving the response
     # while the command is still being processed.
-    command_task = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST))
+    command_task = asyncio.create_task(mqtt_channel.send_message(TEST_REQUEST))
     await asyncio.sleep(0.01)  # yield
 
     # Simulate receiving the response message via MQTT
@@ -153,7 +153,7 @@ async def test_send_command_success(
     assert result == TEST_RESPONSE
 
 
-async def test_send_command_without_request_id(
+async def test_send_message_without_request_id(
     mqtt_session: Mock,
     mqtt_channel: MqttChannel,
     mqtt_message_handler: Callable[[bytes], None],
@@ -166,7 +166,7 @@ async def test_send_command_without_request_id(
     )
 
     with pytest.raises(RoborockException, match="Message must have a request_id"):
-        await mqtt_channel.send_command(test_message)
+        await mqtt_channel.send_message(test_message)
 
 
 async def test_concurrent_commands(
@@ -179,8 +179,8 @@ async def test_concurrent_commands(
 
     # Create multiple test messages with different request IDs
     # Start both commands concurrently
-    task1 = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
-    task2 = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST2, timeout=5.0))
+    task1 = asyncio.create_task(mqtt_channel.send_message(TEST_REQUEST, timeout=5.0))
+    task2 = asyncio.create_task(mqtt_channel.send_message(TEST_REQUEST2, timeout=5.0))
     await asyncio.sleep(0.01)  # yield
 
     # Create responses for both
@@ -209,8 +209,8 @@ async def test_concurrent_commands_same_request_id(
 
     # Create multiple test messages with different request IDs
     # Start both commands concurrently
-    task1 = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
-    task2 = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
+    task1 = asyncio.create_task(mqtt_channel.send_message(TEST_REQUEST, timeout=5.0))
+    task2 = asyncio.create_task(mqtt_channel.send_message(TEST_REQUEST, timeout=5.0))
     await asyncio.sleep(0.01)  # yield
 
     # Create response
@@ -233,7 +233,7 @@ async def test_handle_completed_future(
 ) -> None:
     """Test handling response for an already completed future."""
     # Send request
-    task = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
+    task = asyncio.create_task(mqtt_channel.send_message(TEST_REQUEST, timeout=5.0))
     await asyncio.sleep(0.01)  # yield
 
     # Send the response twice
@@ -255,7 +255,7 @@ async def test_subscribe_callback_with_rpc_response(
 ) -> None:
     """Test that subscribe callback is called independent of RPC handling."""
     # Send request
-    task = asyncio.create_task(mqtt_channel.send_command(TEST_REQUEST, timeout=5.0))
+    task = asyncio.create_task(mqtt_channel.send_message(TEST_REQUEST, timeout=5.0))
     await asyncio.sleep(0.01)  # yield
 
     assert not received_messages


### PR DESCRIPTION
Refactor some of the internal channel details used by the device by separating V1 API connection logic from encoding logic

This creates an "RPC Channel" to separate the logic for establishing connections from doing the "RPC" payload request encoding and response parsing for sending `RoborockCommand` commands.    The existing `send_command` on the channel has been renamed to `send_message` to be more clear since it is sending a `RoborockMessage`. The fallback logic is now behind the RPC interface. 

The motivation for this is because we will likely try to push much of the device connection logic into the background. I'm working on a separate PR that adding A01 protocol and it seems like separating the connection logic from the RPC sending is helpful since when interacting with the devices you only care about sending RPCs.