### PR TITLE
feat: Add property for accessing the current map from the status object

### DIFF
--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -425,6 +425,13 @@ class Status(RoborockBase):
             raise RoborockException("Attempted to get mop_mode before status has been updated.")
         return self.mop_mode.as_dict().get(mop_mode)
 
+    @property
+    def current_map(self) -> int | None:
+        """Returns the current map ID if the map is present."""
+        if self.map_status is not None:
+            return (self.map_status - 3) // 4
+        return None
+
 
 @dataclass
 class S4MaxStatus(Status):

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -234,6 +234,7 @@ def test_status():
     assert s.fan_power == 102
     assert s.dnd_enabled == 0
     assert s.map_status == 3
+    assert s.current_map == 0
     assert s.is_locating == 0
     assert s.lock_status == 0
     assert s.water_box_mode == 203
@@ -260,6 +261,19 @@ def test_status():
     assert s.fan_power == RoborockFanSpeedS7MaxV.balanced
     assert s.mop_mode == RoborockMopModeS7.standard
     assert s.water_box_mode == RoborockMopIntensityS7.intense
+
+
+def test_current_map() -> None:
+    """Test the current map logic based on map status."""
+    s = S7MaxVStatus.from_dict(STATUS)
+    assert s.map_status == 3
+    assert s.current_map == 0
+
+    s.map_status = 7
+    assert s.current_map == 1
+
+    s.map_status = 11
+    assert s.current_map == 2
 
 
 def test_dnd_timer():

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -275,6 +275,9 @@ def test_current_map() -> None:
     s.map_status = 11
     assert s.current_map == 2
 
+    s.map_status = None
+    assert not s.current_map
+
 
 def test_dnd_timer():
     dnd = DnDTimer.from_dict(DND_TIMER)


### PR DESCRIPTION
Add a helper that extracts the current map from the map status to avoid needing to do this math in the caller.