### PR TITLE
fix: Fix "retry" error handling

### DIFF
--- a/roborock/protocols/v1_protocol.py
+++ b/roborock/protocols/v1_protocol.py
@@ -15,7 +15,7 @@ from typing import Any
 from roborock.containers import RRiot
 from roborock.exceptions import RoborockException
 from roborock.protocol import Utils
-from roborock.roborock_message import MessageRetry, RoborockMessage, RoborockMessageProtocol
+from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 from roborock.roborock_typing import RoborockCommand
 from roborock.util import get_next_int
 
@@ -102,15 +102,10 @@ def encode_local_payload(method: CommandType, params: ParamsType) -> RoborockMes
     request = RequestMessage(method=method, params=params)
     payload = request.as_payload(security_data=None)
 
-    message_retry: MessageRetry | None = None
-    if method == RoborockCommand.RETRY_REQUEST and isinstance(params, dict):
-        message_retry = MessageRetry(method=method, retry_id=params["retry_id"])
-
     return RoborockMessage(
         timestamp=request.timestamp,
         protocol=RoborockMessageProtocol.GENERAL_REQUEST,
         payload=payload,
-        message_retry=message_retry,
     )
 
 

--- a/roborock/roborock_message.py
+++ b/roborock/roborock_message.py
@@ -147,12 +147,6 @@ ROBOROCK_DATA_CONSUMABLE_PROTOCOL = [
 
 
 @dataclass
-class MessageRetry:
-    method: str
-    retry_id: int
-
-
-@dataclass
 class RoborockMessage:
     protocol: RoborockMessageProtocol
     payload: bytes | None = None
@@ -160,7 +154,6 @@ class RoborockMessage:
     version: bytes = b"1.0"
     random: int = field(default_factory=lambda: get_next_int(10000, 99999))
     timestamp: int = field(default_factory=lambda: math.floor(time.time()))
-    message_retry: MessageRetry | None = None
 
     def get_request_id(self) -> int | None:
         if self.payload:
@@ -171,14 +164,7 @@ class RoborockMessage:
                     return data_point_response.get("id")
         return None
 
-    def get_retry_id(self) -> int | None:
-        if self.message_retry:
-            return self.message_retry.retry_id
-        return self.get_request_id()
-
     def get_method(self) -> str | None:
-        if self.message_retry:
-            return self.message_retry.method
         protocol = self.protocol
         if self.payload and protocol in [4, 5, 101, 102]:
             payload = json.loads(self.payload.decode())

--- a/roborock/version_1_apis/roborock_local_client_v1.py
+++ b/roborock/version_1_apis/roborock_local_client_v1.py
@@ -69,8 +69,5 @@ class RoborockLocalClientV1(RoborockLocalClient, RoborockClientV1):
         if roborock_message.protocol == RoborockMessageProtocol.GENERAL_REQUEST:
             self._logger.debug(f"id={request_id} Response from method {roborock_message.get_method()}: {response}")
         if response == "retry":
-            retry_id = roborock_message.get_retry_id()
-            return self.send_command(
-                RoborockCommand.RETRY_REQUEST, {"retry_id": retry_id, "retry_count": 8, "method": method}
-            )
+            raise RoborockException(f"Command {method} failed with 'retry' message; Device is busy, try again later")
         return response

--- a/tests/protocols/test_v1_protocol.py
+++ b/tests/protocols/test_v1_protocol.py
@@ -119,7 +119,6 @@ def test_decode_rpc_response(payload: bytes, expected: RoborockBase) -> None:
         version=b"1.0",
         random=97431,
         timestamp=1652547161,
-        message_retry=None,
     )
     decoded_message = decode_rpc_response(message)
     assert decoded_message == expected

--- a/tests/test_roborock_message.py
+++ b/tests/test_roborock_message.py
@@ -11,7 +11,6 @@ def test_roborock_message() -> None:
         message1 = RoborockMessage(
             protocol=RoborockMessageProtocol.RPC_REQUEST,
             payload=json.dumps({"dps": {"101": json.dumps({"id": 4321})}}).encode(),
-            message_retry=None,
         )
         assert message1.get_request_id() == 4321
 
@@ -19,7 +18,6 @@ def test_roborock_message() -> None:
         message2 = RoborockMessage(
             protocol=RoborockMessageProtocol.RPC_RESPONSE,
             payload=json.dumps({"dps": {"94": json.dumps({"id": 444}), "102": json.dumps({"id": 333})}}).encode(),
-            message_retry=None,
         )
         assert message2.get_request_id() == 333
 


### PR DESCRIPTION
Remove the logic for attempting to retry a request which does not work because it is missing an `await` when sending the command, which returns an unwaited coroutine. Since it's already broken we'll just fail with a `RoborockException` and retry at a higher level to keep this simple.