### PR TITLE
chore: avoid re-parsing RoborockMessages and replace with passing explicit arguments

### DIFF
--- a/roborock/roborock_message.py
+++ b/roborock/roborock_message.py
@@ -256,23 +256,3 @@ class RoborockMessage:
                     data_point_response = json.loads(data_point)
                     return data_point_response.get("id")
         return None
-
-    def get_method(self) -> str | None:
-        protocol = self.protocol
-        if self.payload and protocol in [4, 5, 101, 102]:
-            payload = json.loads(self.payload.decode())
-            for data_point_number, data_point in payload.get("dps").items():
-                if data_point_number in ["101", "102"]:
-                    data_point_response = json.loads(data_point)
-                    return data_point_response.get("method")
-        return None
-
-    def get_params(self) -> list | dict | None:
-        protocol = self.protocol
-        if self.payload and protocol in [4, 101, 102]:
-            payload = json.loads(self.payload.decode())
-            for data_point_number, data_point in payload.get("dps").items():
-                if data_point_number in ["101", "102"]:
-                    data_point_response = json.loads(data_point)
-                    return data_point_response.get("params")
-        return None


### PR DESCRIPTION
Now pass explicit arguments to the send message functions rather than encoding then decoding the messages.