### PR TITLE
chore: extract map parser into a separate function to share with new api

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
-import secrets
 import time
 from abc import ABC, abstractmethod
 from typing import Any
@@ -37,14 +35,11 @@ class RoborockClient(ABC):
     def __init__(self, device_info: DeviceData) -> None:
         """Initialize RoborockClient."""
         self.device_info = device_info
-        self._nonce = secrets.token_bytes(16)
         self._waiting_queue: dict[int, RoborockFuture] = {}
         self._last_device_msg_in = time.monotonic()
         self._last_disconnection = time.monotonic()
         self.keep_alive = KEEPALIVE
-        self._diagnostic_data: dict[str, dict[str, Any]] = {
-            "misc_info": {"Nonce": base64.b64encode(self._nonce).decode("utf-8")}
-        }
+        self._diagnostic_data: dict[str, dict[str, Any]] = {}
         self.is_available: bool = True
 
     async def async_release(self) -> None:

--- a/roborock/protocol.py
+++ b/roborock/protocol.py
@@ -148,6 +148,26 @@ class Utils:
         return ciphertext
 
     @staticmethod
+    def encrypt_cbc(plaintext: bytes, token: bytes) -> bytes:
+        """Encrypt plaintext with a given token using cbc mode.
+
+        This is currently used for testing purposes only.
+
+        :param bytes plaintext: Plaintext (json) to encrypt
+        :param bytes token: Token to use
+        :return: Encrypted bytes
+        """
+        if not isinstance(plaintext, bytes):
+            raise TypeError("plaintext requires bytes")
+        Utils.verify_token(token)
+        iv = bytes(AES.block_size)
+        cipher = AES.new(token, AES.MODE_CBC, iv)
+        if plaintext:
+            plaintext = pad(plaintext, AES.block_size)
+            return cipher.encrypt(plaintext)
+        return plaintext
+
+    @staticmethod
     def decrypt_cbc(ciphertext: bytes, token: bytes) -> bytes:
         """Decrypt ciphertext with a given token using cbc mode.
 

--- a/roborock/protocols/v1_protocol.py
+++ b/roborock/protocols/v1_protocol.py
@@ -7,6 +7,7 @@ import json
 import logging
 import math
 import secrets
+import struct
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -43,6 +44,10 @@ class SecurityData:
     def to_dict(self) -> dict[str, Any]:
         """Convert security data to a dictionary for sending in the payload."""
         return {"security": {"endpoint": self.endpoint, "nonce": self.nonce.hex().lower()}}
+
+    def to_diagnostic_data(self) -> dict[str, Any]:
+        """Convert security data to a dictionary for debugging purposes."""
+        return {"nonce": self.nonce.hex().lower()}
 
 
 def create_security_data(rriot: RRiot) -> SecurityData:
@@ -142,3 +147,37 @@ def decode_rpc_response(message: RoborockMessage) -> dict[str, Any]:
     if not isinstance(result, dict):
         raise RoborockException(f"Invalid V1 message format: 'result' should be a dictionary for {message.payload!r}")
     return result
+
+
+@dataclass
+class MapResponse:
+    """Data structure for the V1 Map response."""
+
+    request_id: int
+    """The request ID of the map response."""
+
+    data: bytes
+    """The map data, decrypted and decompressed."""
+
+
+def create_map_response_decoder(security_data: SecurityData) -> Callable[[RoborockMessage], MapResponse]:
+    """Create a decoder for V1 map response messages."""
+
+    def _decode_map_response(message: RoborockMessage) -> MapResponse:
+        """Decode a V1 map response message."""
+        if not message.payload or len(message.payload) < 24:
+            raise RoborockException("Invalid V1 map response format: missing payload")
+        header, body = message.payload[:24], message.payload[24:]
+        [endpoint, _, request_id, _] = struct.unpack("<8s8sH6s", header)
+        if not endpoint.decode().startswith(security_data.endpoint):
+            raise RoborockException(
+                f"Invalid V1 map response endpoint: {endpoint!r}, expected {security_data.endpoint!r}"
+            )
+        try:
+            decrypted = Utils.decrypt_cbc(body, security_data.nonce)
+        except ValueError as err:
+            raise RoborockException("Failed to decode map message payload") from err
+        decompressed = Utils.decompress(decrypted)
+        return MapResponse(request_id=request_id, data=decompressed)
+
+    return _decode_map_response

--- a/roborock/version_1_apis/roborock_local_client_v1.py
+++ b/roborock/version_1_apis/roborock_local_client_v1.py
@@ -60,7 +60,7 @@ class RoborockLocalClientV1(RoborockClientV1, RoborockClient):
         self.transport: Transport | None = None
         self._mutex = Lock()
         self.keep_alive_task: TimerHandle | None = None
-        RoborockClientV1.__init__(self, device_data, "abc")
+        RoborockClientV1.__init__(self, device_data, security_data=None)
         RoborockClient.__init__(self, device_data)
         self._local_protocol = _LocalProtocol(self._data_received, self._connection_lost)
         self._encoder: Encoder = create_local_encoder(device_data.device.local_key)

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -9,7 +9,7 @@ USER_EMAIL = "user@domain.com"
 BASE_URL = "https://usiot.roborock.com"
 
 USER_ID = "user123"
-K_VALUE = "domain123"
+K_VALUE = "qiCNieZa"
 USER_DATA = {
     "uid": 123456,
     "tokentype": "token_type",

--- a/tests/protocols/test_v1_protocol.py
+++ b/tests/protocols/test_v1_protocol.py
@@ -7,8 +7,11 @@ import pytest
 from freezegun import freeze_time
 
 from roborock.containers import RoborockBase, UserData
+from roborock.exceptions import RoborockException
+from roborock.protocol import Utils
 from roborock.protocols.v1_protocol import (
     SecurityData,
+    create_map_response_decoder,
     create_mqtt_payload_encoder,
     decode_rpc_response,
     encode_local_payload,
@@ -20,7 +23,12 @@ from .. import mock_data
 
 USER_DATA = UserData.from_dict(mock_data.USER_DATA)
 TEST_REQUEST_ID = 44444
-SECURITY_DATA = SecurityData(endpoint="3PBTIjvc", nonce=b"fake-nonce")
+TEST_ENDPOINT = "87ItGWdb"
+TEST_ENDPOINT_BYTES = TEST_ENDPOINT.encode()
+SECURITY_DATA = SecurityData(
+    endpoint=TEST_ENDPOINT,
+    nonce=b"\x91\xbe\x10\xc9b+\x9d\x8a\xcdH*\x19\xf6\xfe\x81h",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -62,7 +70,7 @@ def test_encode_local_payload(command, params, expected):
         (
             RoborockCommand.GET_STATUS,
             None,
-            b'{"dps":{"101":"{\\"id\\":44444,\\"method\\":\\"get_status\\",\\"params\\":[],\\"security\\":{\\"endpoint\\":\\"3PBTIjvc\\",\\"nonce\\":\\"66616b652d6e6f6e6365\\"}}"},"t":1737374400}',
+            b'{"dps":{"101":"{\\"id\\":44444,\\"method\\":\\"get_status\\",\\"params\\":[],\\"security\\":{\\"endpoint\\":\\"87ItGWdb\\",\\"nonce\\":\\"91be10c9622b9d8acd482a19f6fe8168\\"}}"},"t":1737374400}',
         )
     ],
 )
@@ -122,3 +130,70 @@ def test_decode_rpc_response(payload: bytes, expected: RoborockBase) -> None:
     )
     decoded_message = decode_rpc_response(message)
     assert decoded_message == expected
+
+
+def test_create_map_response_decoder():
+    """Test creating and using a map response decoder."""
+    test_data = b"some map\n"
+    compressed_data = (
+        b"\x1f\x8b\x08\x08\xf9\x13\x99h\x00\x03foo\x00+\xce\xcfMU\xc8M,\xe0\x02\x00@\xdb\xc6\x1a\t\x00\x00\x00"
+    )
+
+    # Create header: endpoint(8) + padding(8) + request_id(2) + padding(6)
+    # request_id = 44508 (0xaddc in little endian)
+    header = TEST_ENDPOINT_BYTES + b"\x00" * 8 + b"\xdc\xad" + b"\x00" * 6
+    encrypted_data = Utils.encrypt_cbc(compressed_data, SECURITY_DATA.nonce)
+    payload = header + encrypted_data
+
+    message = RoborockMessage(
+        protocol=RoborockMessageProtocol.MAP_RESPONSE,
+        payload=payload,
+        seq=12750,
+        version=b"1.0",
+        random=97431,
+        timestamp=1652547161,
+    )
+
+    decoder = create_map_response_decoder(SECURITY_DATA)
+    result = decoder(message)
+
+    assert result.request_id == 44508
+    assert result.data == test_data
+
+
+def test_create_map_response_decoder_invalid_endpoint():
+    """Test map response decoder with invalid endpoint."""
+    # Create header with wrong endpoint
+    header = b"wrongend" + b"\x00" * 8 + b"\xdc\xad" + b"\x00" * 6
+    payload = header + b"encrypted_data"
+
+    message = RoborockMessage(
+        protocol=RoborockMessageProtocol.MAP_RESPONSE,
+        payload=payload,
+        seq=12750,
+        version=b"1.0",
+        random=97431,
+        timestamp=1652547161,
+    )
+
+    decoder = create_map_response_decoder(SECURITY_DATA)
+
+    with pytest.raises(RoborockException, match="Invalid V1 map response endpoint"):
+        decoder(message)
+
+
+def test_create_map_response_decoder_invalid_payload():
+    """Test map response decoder with invalid payload."""
+    message = RoborockMessage(
+        protocol=RoborockMessageProtocol.MAP_RESPONSE,
+        payload=b"short",  # Too short payload
+        seq=12750,
+        version=b"1.0",
+        random=97431,
+        timestamp=1652547161,
+    )
+
+    decoder = create_map_response_decoder(SECURITY_DATA)
+
+    with pytest.raises(RoborockException, match="Invalid V1 map response format: missing payload"):
+        decoder(message)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -22,6 +22,7 @@ from .mock_data import (
     CONSUMABLE,
     DND_TIMER,
     HOME_DATA_RAW,
+    K_VALUE,
     LOCAL_KEY,
     PRODUCT_ID,
     STATUS,
@@ -130,7 +131,7 @@ def test_user_data():
     assert ud.rriot.u == "user123"
     assert ud.rriot.s == "pass123"
     assert ud.rriot.h == "unknown123"
-    assert ud.rriot.k == "domain123"
+    assert ud.rriot.k == K_VALUE
     assert ud.rriot.r.r == "US"
     assert ud.rriot.r.a == "https://api-us.roborock.com"
     assert ud.rriot.r.m == "tcp://mqtt-us.roborock.com:8883"


### PR DESCRIPTION
Simplify how security data works to avoid passing all the way up to the parent class.

A follow up PR will separate `MapResponse` into a generic type that has request id plus data pairs that can be used across protocols.