### PR TITLE
feat: Improve session command for CLI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -239,6 +239,25 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "click-shell"
+version = "2.1"
+description = "An extension to click that easily turns your click app into a shell utility"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "click-shell-2.1.tar.gz", hash = "sha256:ce0c91faae284c41a39bec966f928791ad4a45763755445f1fe2041fd091aa37"},
+    {file = "click_shell-2.1-py2.py3-none-any.whl", hash = "sha256:2d971a2e50eb7ad387cf0ce79ba4b844e66e0580784e2efe2df58b50a2f047f0"},
+]
+
+[package.dependencies]
+click = ">=6.0"
+
+[package.extras]
+readline = ["gnureadline"]
+windows = ["pyreadline"]
+
+[[package]]
 name = "codespell"
 version = "2.4.1"
 description = "Fix common misspellings in text files"
@@ -1623,4 +1642,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "c5594d018cffe1e085cf1eddf1884d8acbf99c283fad97edb2e8762790fc56ea"
+content-hash = "592d0befc63c27485c5bcea0853acfba35f97a0d72d33040b6aadd13d3bf95f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ construct = "^2.10.57"
 vacuum-map-parser-roborock = "*"
 pyrate-limiter = "^3.7.0"
 aiomqtt = "^2.3.2"
+click-shell = "^2.1"
 
 
 [build-system]

--- a/roborock/util.py
+++ b/roborock/util.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-import functools
 import logging
-from asyncio import AbstractEventLoop, TimerHandle
+from asyncio import TimerHandle
 from collections.abc import Callable, Coroutine, MutableMapping
 from typing import Any, TypeVar
 
@@ -16,15 +15,6 @@ DEFAULT_TIME_ZONE: datetime.tzinfo | None = datetime.datetime.now().astimezone()
 
 def unpack_list(value: list[T], size: int) -> list[T | None]:
     return (value + [None] * size)[:size]  # type: ignore
-
-
-def get_running_loop_or_create_one() -> AbstractEventLoop:
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    return loop
 
 
 def parse_datetime_to_roborock_datetime(
@@ -58,19 +48,6 @@ def parse_time_to_datetime(
     )
 
     return parse_datetime_to_roborock_datetime(start_datetime, end_datetime)
-
-
-def run_sync():
-    loop = get_running_loop_or_create_one()
-
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapped(*args, **kwargs):
-            return loop.run_until_complete(func(*args, **kwargs))
-
-        return wrapped
-
-    return decorator
 
 
 class RepeatableTask:


### PR DESCRIPTION
Improve the session command for the CLI to allow having commands subcommands present both on the normal CLI and the session command. This is prep before adding additional commands from additional traits.

The syntax will be an interactive session like this:

```
$ roborock session
roborock> list-devices
...
roborock> status --device_id <device_id>
```