### PR TITLE
fix: Fix bug parsing MultiMapsListMapInfo

### DIFF
--- a/roborock/containers.py
+++ b/roborock/containers.py
@@ -109,8 +109,6 @@ def _decamelize(s: str):
 
 @dataclass
 class RoborockBase:
-    _ignore_keys = []  # type: ignore
-
     @staticmethod
     def _convert_to_class_obj(class_type: type, value):
         if get_origin(class_type) is list:
@@ -684,19 +682,20 @@ class MultiMapsListMapInfoBakMaps(RoborockBase):
 
 @dataclass
 class MultiMapsListMapInfo(RoborockBase):
-    _ignore_keys = ["mapFlag"]
-
-    mapFlag: int
+    map_flag: int
     name: str
     add_time: Any | None = None
     length: Any | None = None
     bak_maps: list[MultiMapsListMapInfoBakMaps] | None = None
 
+    @property
+    def mapFlag(self) -> int:
+        """Alias for map_flag, returns the map flag as an integer."""
+        return self.map_flag
+
 
 @dataclass
 class MultiMapsList(RoborockBase):
-    _ignore_keys = ["mapFlag"]
-
     max_multi_map: int | None = None
     max_bak_map: int | None = None
     multi_map_count: int | None = None

--- a/tests/__snapshots__/test_containers.ambr
+++ b/tests/__snapshots__/test_containers.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_multi_maps_list_info
+  MultiMapsList(max_multi_map=4, max_bak_map=1, multi_map_count=2, map_info=[MultiMapsListMapInfo(map_flag=0, name='Downstairs', add_time=1757636125, length=10, bak_maps=[MultiMapsListMapInfoBakMaps(mapflag=None, add_time=1739205442)]), MultiMapsListMapInfo(map_flag=1, name='Foyer', add_time=1734283706, length=5, bak_maps=[MultiMapsListMapInfoBakMaps(mapflag=None, add_time=1728184107)])])
+# ---

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Any
 
+from syrupy import SnapshotAssertion
+
 from roborock import CleanRecord, CleanSummary, Consumable, DnDTimer, HomeData, S7MaxVStatus, UserData
 from roborock.b01_containers import (
     B01Fault,
@@ -20,7 +22,7 @@ from roborock.code_mappings import (
     RoborockMopModeS7,
     RoborockStateCode,
 )
-from roborock.containers import RoborockBase
+from roborock.containers import MultiMapsList, RoborockBase
 
 from .mock_data import (
     CLEAN_RECORD,
@@ -427,3 +429,55 @@ def test_b01props_deserialization():
     assert deserialized.status == WorkStatusMapping.SWEEP_MOPING_2
     assert deserialized.wind == SCWindMapping.SUPER_STRONG
     assert deserialized.net_status.ip == "192.168.1.102"
+
+
+def test_multi_maps_list_info(snapshot: SnapshotAssertion) -> None:
+    """Test that MultiMapsListInfo can be deserialized correctly."""
+    data = {
+        "max_multi_map": 4,
+        "max_bak_map": 1,
+        "multi_map_count": 2,
+        "map_info": [
+            {
+                "mapFlag": 0,
+                "add_time": 1757636125,
+                "length": 10,
+                "name": "Downstairs",
+                "bak_maps": [{"mapFlag": 4, "add_time": 1739205442}],
+                "rooms": [
+                    {"id": 16, "tag": 12, "iot_name_id": "6990322", "iot_name": "Room"},
+                    {"id": 17, "tag": 15, "iot_name_id": "7140977", "iot_name": "Room"},
+                    {"id": 18, "tag": 12, "iot_name_id": "6985623", "iot_name": "Room"},
+                    {"id": 19, "tag": 14, "iot_name_id": "6990378", "iot_name": "Room"},
+                    {"id": 20, "tag": 10, "iot_name_id": "7063728", "iot_name": "Room"},
+                    {"id": 22, "tag": 12, "iot_name_id": "6995506", "iot_name": "Room"},
+                    {"id": 23, "tag": 15, "iot_name_id": "7140979", "iot_name": "Room"},
+                    {"id": 25, "tag": 13, "iot_name_id": "6990383", "iot_name": "Room"},
+                    {"id": 24, "tag": -1, "iot_name_id": "-1", "iot_name": "Room"},
+                ],
+                "furnitures": [
+                    {"id": 1, "type": 46, "subtype": 2},
+                    {"id": 2, "type": 47, "subtype": 0},
+                    {"id": 3, "type": 56, "subtype": 0},
+                    {"id": 4, "type": 43, "subtype": 0},
+                    {"id": 5, "type": 44, "subtype": 0},
+                    {"id": 6, "type": 44, "subtype": 0},
+                    {"id": 7, "type": 44, "subtype": 0},
+                    {"id": 8, "type": 46, "subtype": 0},
+                    {"id": 9, "type": 46, "subtype": 0},
+                ],
+            },
+            {
+                "mapFlag": 1,
+                "add_time": 1734283706,
+                "length": 5,
+                "name": "Foyer",
+                "bak_maps": [{"mapFlag": 5, "add_time": 1728184107}],
+                "rooms": [],
+                "furnitures": [],
+            },
+        ],
+    }
+    deserialized = MultiMapsList.from_dict(data)
+    assert isinstance(deserialized, MultiMapsList)
+    assert deserialized == snapshot


### PR DESCRIPTION
This fixes a bug in likely added in #426 when rewriting the object parsing code. This removes the `ignore_keys` attribute and fixes the map flag so that it can be parsed correctly.

Fixes #472

This was previously fixed in https://github.com/Python-roborock/python-roborock/commit/cfaeb419e188510ade5bc1506214c9b3d2afeb18 -- this time, also including a test to ensure we don't have future regressions.