### PR TITLE
fix: fix a bug with local / mqtt fallback

### DIFF
--- a/tests/devices/test_v1_channel.py
+++ b/tests/devices/test_v1_channel.py
@@ -497,6 +497,9 @@ async def test_v1_channel_full_subscribe_and_command_flow(
         local_session=mock_local_session,
         cache=InMemoryCache(),
     )
+    # Get a handle to the V1RpcChannel. It may change which connection is
+    # active, but getting now to reproduce a bug where it doesn't change.
+    rpc_channel = v1_channel.rpc_channel
 
     # Mock network info for local connection
     callback = Mock()
@@ -512,7 +515,7 @@ async def test_v1_channel_full_subscribe_and_command_flow(
 
     # Send a command (should use local)
     mock_local_channel.response_queue.append(TEST_RESPONSE)
-    result = await v1_channel.rpc_channel.send_command(
+    result = await rpc_channel.send_command(
         RoborockCommand.GET_STATUS,
         response_type=S5MaxStatus,
     )


### PR DESCRIPTION
Pull out a fix from #471 with an improved solution. This fixes an issue where `rpc_channel` does not internalize the fallback behavior. Now instead of returning a different channel depending on the state, we now return a single channel that id dynamic.

The combined channel is now a "pick first available" channel. This allows us to make the mqtt channel optional in the future as well (not yet supported by v1 channel, but this is one less thing to fix to support that)