### PR TITLE
feat: add v4 for code login

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,6 +271,21 @@ def mock_rest() -> aioresponses:
             status=200,
             payload={"api": None, "code": 200, "result": None, "status": "ok", "success": True},
         )
+        mocked.post(
+            re.compile(r"https://.*iot\.roborock\.com/api/v4/email/code/send.*"),
+            status=200,
+            payload={"code": 200, "data": None, "msg": "success"},
+        )
+        mocked.post(
+            re.compile(r"https://.*iot\.roborock\.com/api/v3/key/sign.*"),
+            status=200,
+            payload={"code": 200, "data": {"k": "mock_k"}, "msg": "success"},
+        )
+        mocked.post(
+            re.compile(r"https://.*iot\.roborock\.com/api/v4/auth/email/login/code.*"),
+            status=200,
+            payload={"code": 200, "data": USER_DATA, "msg": "success"},
+        )
         yield mocked
 
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -63,3 +63,11 @@ async def test_execute_scene(mock_rest):
     ud = await api.pass_login("password")
     await api.execute_scene(ud, 123456)
     mock_rest.assert_any_call("https://api-us.roborock.com/user/scene/123456/execute", "post")
+
+
+async def test_code_login_v4_flow(mock_rest) -> None:
+    """Test that we can login with a code and we get back the correct userdata object."""
+    api = RoborockApiClient(username="test_user@gmail.com")
+    await api.request_code_v4()
+    ud = await api.code_login_v4(4123, "US", 1)
+    assert ud == UserData.from_dict(USER_DATA)


### PR DESCRIPTION
Roborock is keeping me on my toes...

All new accounts have to login via the v4 endpoint (existing accounts can login with it as well) as accounts are now per country. i.e. you can make a new account in Cambodia with the exact same email.

Fixes #485

We will need to figure out how to get the user to specify their country code and country abbreviation, open to any ideas via a follow up or in HA itself.