### PR TITLE
chore: Try `poetry run pdoc` to fix CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Dependencies
         run: poetry install
         shell: bash
-      - run: pdoc ./roborock -o docs/pdoc
+      - run: poetry run pdoc ./roborock -o docs/pdoc
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
Try to fix CI for building pdoc. Example failure https://github.com/Python-roborock/python-roborock/actions/runs/18082881173