### PR TITLE
Add a v1 device trait for map contents

### DIFF
--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -48,6 +48,7 @@ from roborock.devices.device_manager import DeviceManager, create_device_manager
 from roborock.devices.traits import Trait
 from roborock.devices.traits.v1 import V1TraitMixin
 from roborock.devices.traits.v1.consumeable import ConsumableAttribute
+from roborock.devices.traits.v1.map_content import MapContentTrait
 from roborock.protocol import MessageParser
 from roborock.version_1_apis.roborock_mqtt_client_v1 import RoborockMqttClientV1
 from roborock.web_api import RoborockApiClient
@@ -453,6 +454,49 @@ async def maps(ctx, device_id: str):
 
 @session.command()
 @click.option("--device_id", required=True)
+@click.option("--output-file", required=True, help="Path to save the map image.")
+@click.pass_context
+@async_command
+async def map_image(ctx, device_id: str, output_file: str):
+    """Get device map image and save it to a file."""
+    context: RoborockContext = ctx.obj
+    trait: MapContentTrait = await _v1_trait(context, device_id, lambda v1: v1.map_content)
+    if trait.image_content:
+        with open(output_file, "wb") as f:
+            f.write(trait.image_content)
+        click.echo(f"Map image saved to {output_file}")
+    else:
+        click.echo("No map image content available.")
+
+
+@session.command()
+@click.option("--device_id", required=True)
+@click.option("--include_path", is_flag=True, default=False, help="Include path data in the output.")
+@click.pass_context
+@async_command
+async def map_data(ctx, device_id: str, include_path: bool):
+    """Get parsed map data as JSON."""
+    context: RoborockContext = ctx.obj
+    trait: MapContentTrait = await _v1_trait(context, device_id, lambda v1: v1.map_content)
+    if not trait.map_data:
+        click.echo("No parsed map data available.")
+        return
+
+    # Pick some parts of the map data to display.
+    data_summary = {
+        "charger": trait.map_data.charger.as_dict() if trait.map_data.charger else None,
+        "image_size": trait.map_data.image.data.size if trait.map_data.image else None,
+        "vacuum_position": trait.map_data.vacuum_position.as_dict() if trait.map_data.vacuum_position else None,
+        "calibration": trait.map_data.calibration(),
+        "zones": [z.as_dict() for z in trait.map_data.zones or ()],
+    }
+    if include_path and trait.map_data.path:
+        data_summary["path"] = trait.map_data.path.as_dict()
+    click.echo(dump_json(data_summary))
+
+
+@session.command()
+@click.option("--device_id", required=True)
 @click.pass_context
 @async_command
 async def consumables(ctx, device_id: str):
@@ -727,6 +771,8 @@ cli.add_command(clean_summary)
 cli.add_command(volume)
 cli.add_command(set_volume)
 cli.add_command(maps)
+cli.add_command(map_image)
+cli.add_command(map_data)
 cli.add_command(consumables)
 cli.add_command(reset_consumable)
 cli.add_command(rooms)

--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -14,6 +14,7 @@ from roborock.containers import (
     UserData,
 )
 from roborock.devices.device import RoborockDevice
+from roborock.map.map_parser import MapParserConfig
 from roborock.mqtt.roborock_session import create_lazy_mqtt_session
 from roborock.mqtt.session import MqttSession
 from roborock.protocol import create_mqtt_params
@@ -130,6 +131,7 @@ async def create_device_manager(
     user_data: UserData,
     home_data_api: HomeDataApi,
     cache: Cache | None = None,
+    map_parser_config: MapParserConfig | None = None,
 ) -> DeviceManager:
     """Convenience function to create and initialize a DeviceManager.
 
@@ -149,7 +151,14 @@ async def create_device_manager(
         match device.pv:
             case DeviceVersion.V1:
                 channel = create_v1_channel(user_data, mqtt_params, mqtt_session, device, cache)
-                trait = v1.create(product, home_data, channel.rpc_channel, channel.mqtt_rpc_channel)
+                trait = v1.create(
+                    product,
+                    home_data,
+                    channel.rpc_channel,
+                    channel.mqtt_rpc_channel,
+                    channel.map_rpc_channel,
+                    map_parser_config=map_parser_config,
+                )
             case DeviceVersion.A01:
                 channel = create_mqtt_channel(user_data, mqtt_params, mqtt_session, device)
                 trait = a01.create(product, channel)

--- a/roborock/devices/traits/v1/__init__.py
+++ b/roborock/devices/traits/v1/__init__.py
@@ -6,11 +6,13 @@ from dataclasses import dataclass, field, fields
 from roborock.containers import HomeData, HomeDataProduct
 from roborock.devices.traits import Trait
 from roborock.devices.v1_rpc_channel import V1RpcChannel
+from roborock.map.map_parser import MapParserConfig
 
 from .clean_summary import CleanSummaryTrait
 from .common import V1TraitMixin
 from .consumeable import ConsumableTrait
 from .do_not_disturb import DoNotDisturbTrait
+from .map_content import MapContentTrait
 from .maps import MapsTrait
 from .rooms import RoomsTrait
 from .status import StatusTrait
@@ -26,6 +28,7 @@ __all__ = [
     "CleanSummaryTrait",
     "SoundVolumeTrait",
     "MapsTrait",
+    "MapContentTrait",
     "ConsumableTrait",
 ]
 
@@ -44,18 +47,25 @@ class PropertiesApi(Trait):
     sound_volume: SoundVolumeTrait
     rooms: RoomsTrait
     maps: MapsTrait
+    map_content: MapContentTrait
     consumables: ConsumableTrait
 
     # In the future optional fields can be added below based on supported features
 
     def __init__(
-        self, product: HomeDataProduct, home_data: HomeData, rpc_channel: V1RpcChannel, mqtt_rpc_channel: V1RpcChannel
+        self,
+        product: HomeDataProduct,
+        home_data: HomeData,
+        rpc_channel: V1RpcChannel,
+        mqtt_rpc_channel: V1RpcChannel,
+        map_rpc_channel: V1RpcChannel,
+        map_parser_config: MapParserConfig | None = None,
     ) -> None:
         """Initialize the V1TraitProps."""
         self.status = StatusTrait(product)
         self.rooms = RoomsTrait(home_data)
         self.maps = MapsTrait(self.status)
-
+        self.map_content = MapContentTrait(map_parser_config)
         # This is a hack to allow setting the rpc_channel on all traits. This is
         # used so we can preserve the dataclass behavior when the values in the
         # traits are updated, but still want to allow them to have a reference
@@ -68,12 +78,19 @@ class PropertiesApi(Trait):
             # to use the mqtt_rpc_channel (cloud only) instead of the rpc_channel (adaptive)
             if hasattr(trait, "mqtt_rpc_channel"):
                 trait._rpc_channel = mqtt_rpc_channel
+            elif hasattr(trait, "map_rpc_channel"):
+                trait._rpc_channel = map_rpc_channel
             else:
                 trait._rpc_channel = rpc_channel
 
 
 def create(
-    product: HomeDataProduct, home_data: HomeData, rpc_channel: V1RpcChannel, mqtt_rpc_channel: V1RpcChannel
+    product: HomeDataProduct,
+    home_data: HomeData, 
+    rpc_channel: V1RpcChannel,
+    mqtt_rpc_channel: V1RpcChannel,
+    map_rpc_channel: V1RpcChannel,
+    map_parser_config: MapParserConfig | None = None,
 ) -> PropertiesApi:
     """Create traits for V1 devices."""
-    return PropertiesApi(product, home_data, rpc_channel, mqtt_rpc_channel)
+    return PropertiesApi(product, home_data, rpc_channel, mqtt_rpc_channel, map_rpc_channel, map_parser_config)

--- a/roborock/devices/traits/v1/__init__.py
+++ b/roborock/devices/traits/v1/__init__.py
@@ -86,7 +86,7 @@ class PropertiesApi(Trait):
 
 def create(
     product: HomeDataProduct,
-    home_data: HomeData, 
+    home_data: HomeData,
     rpc_channel: V1RpcChannel,
     mqtt_rpc_channel: V1RpcChannel,
     map_rpc_channel: V1RpcChannel,

--- a/roborock/devices/traits/v1/common.py
+++ b/roborock/devices/traits/v1/common.py
@@ -133,3 +133,13 @@ def mqtt_rpc_channel(cls):
 
     cls.mqtt_rpc_channel = True  # type: ignore[attr-defined]
     return wrapper
+
+
+def map_rpc_channel(cls):
+    """Decorator to mark a function as cloud only using the map rpc format."""
+
+    def wrapper(*args, **kwargs):
+        return cls(*args, **kwargs)
+
+    cls.map_rpc_channel = True  # type: ignore[attr-defined]
+    return wrapper

--- a/roborock/devices/traits/v1/map_content.py
+++ b/roborock/devices/traits/v1/map_content.py
@@ -1,0 +1,49 @@
+"""Trait for fetching the map content from Roborock devices."""
+import logging
+from dataclasses import dataclass
+
+from vacuum_map_parser_base.map_data import MapData
+
+from roborock.containers import RoborockBase
+from roborock.devices.traits.v1 import common
+from roborock.map.map_parser import MapParser, MapParserConfig
+from roborock.roborock_typing import RoborockCommand
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class MapContent(RoborockBase):
+    """Dataclass representing map content."""
+
+    image_content: bytes | None = None
+    """The rendered image of the map in PNG format."""
+
+    map_data: MapData | None = None
+    """The parsed map data which contains metadata for points on the map."""
+
+
+@common.map_rpc_channel
+class MapContentTrait(MapContent, common.V1TraitMixin):
+    """Trait for fetching the map content."""
+
+    command = RoborockCommand.GET_MAP_V1
+
+    def __init__(self, map_parser_config: MapParserConfig | None = None) -> None:
+        """Initialize MapContentTrait."""
+        super().__init__()
+        self._map_parser = MapParser(map_parser_config or MapParserConfig())
+
+    def _parse_response(self, response: common.V1ResponseData) -> MapContent:
+        """Parse the response from the device into a MapContentTrait instance."""
+        if not isinstance(response, bytes):
+            raise ValueError(f"Unexpected MapContentTrait response format: {type(response)}")
+
+        parsed_data = self._map_parser.parse(response)
+        if parsed_data is None:
+            raise ValueError("Failed to parse map data")
+
+        return MapContent(
+            image_content=parsed_data.image_content,
+            map_data=parsed_data.map_data,
+        )

--- a/roborock/devices/v1_rpc_channel.py
+++ b/roborock/devices/v1_rpc_channel.py
@@ -160,7 +160,6 @@ class PayloadEncodedV1RpcChannel(BaseV1RpcChannel):
                 else:
                     future.set_result(decoded.data)
 
-        message = self._payload_encoder(request_message)
         unsub = await self._channel.subscribe(find_response)
         try:
             await self._channel.publish(message)

--- a/roborock/devices/v1_rpc_channel.py
+++ b/roborock/devices/v1_rpc_channel.py
@@ -21,6 +21,8 @@ from roborock.protocols.v1_protocol import (
     SecurityData,
     create_map_response_decoder,
     decode_rpc_response,
+    MapResponse,
+    ResponseMessage,
 )
 from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 
@@ -114,39 +116,50 @@ class PickFirstAvailable(BaseV1RpcChannel):
         raise RoborockException("No available connection to send command")
 
 
-class RpcPublisher:
-    """Helper to create send and receive messages on a channel."""
+class PayloadEncodedV1RpcChannel(BaseV1RpcChannel):
+    """Protocol for V1 channels that send encoded commands."""
 
     def __init__(
         self,
         name: str,
         channel: MqttChannel | LocalChannel,
         payload_encoder: Callable[[RequestMessage], RoborockMessage],
+        decoder: Callable[[RoborockMessage], ResponseMessage | MapResponse] | None = None,
     ) -> None:
-        """Initialize the RPC publisher."""
+        """Initialize the channel with a raw channel and an encoder function."""
         self._name = name
         self._channel = channel
         self._payload_encoder = payload_encoder
+        self._decoder = decoder
 
-    async def publish_and_wait(
+    async def _send_raw_command(
         self,
-        request_message: RequestMessage,
-        find_response: Callable[[RoborockMessage], None],
-        future: asyncio.Future[_V],
-    ) -> _V:
-        """Helper to send a message and wait for a future to complete.
-
-        The find_response function will be called for each incoming message. The
-        function should check the message and call future.set_result or
-        future.set_exception as appropriate when the response is found.
-        """
+        method: CommandType,
+        *,
+        params: ParamsType = None,
+    ) -> ResponseData | bytes:
+        """Send a command and return a parsed response RoborockBase type."""
+        request_message = RequestMessage(method, params=params)
         _LOGGER.debug(
-            "Sending command (%s, request_id=%s): %s, params=%s",
-            self._name,
-            request_message.request_id,
-            request_message.method,
-            request_message.params,
+            "Sending command (%s, request_id=%s): %s, params=%s", self._name, request_message.request_id, method, params
         )
+        message = self._payload_encoder(request_message)
+
+        future: asyncio.Future[ResponseData | bytes] = asyncio.Future()
+
+        def find_response(response_message: RoborockMessage) -> None:
+            try:
+                decoded = self._decoder(response_message)
+            except RoborockException as ex:
+                _LOGGER.debug("Exception while decoding message (%s): %s", response_message, ex)
+                return
+            _LOGGER.debug("Received response (%s, request_id=%s)", self._name, decoded.request_id)
+            if decoded.request_id == request_message.request_id:
+                if isinstance(decoded, ResponseMessage) and decoded.api_error:
+                    future.set_exception(decoded.api_error)
+                else:
+                    future.set_result(decoded.data)
+
         message = self._payload_encoder(request_message)
         unsub = await self._channel.subscribe(find_response)
         try:
@@ -158,111 +171,39 @@ class RpcPublisher:
         finally:
             unsub()
 
-
-class PayloadEncodedV1RpcChannel(BaseV1RpcChannel):
-    """Protocol for V1 channels that send encoded commands."""
-
-    def __init__(self, publisher: RpcPublisher) -> None:
-        """Initialize the channel with a raw channel and an encoder function."""
-        self._name = publisher._name
-        self._publisher = publisher
-
-    async def _send_raw_command(
-        self,
-        method: CommandType,
-        *,
-        params: ParamsType = None,
-    ) -> ResponseData:
-        """Send a command and return a parsed response RoborockBase type."""
-        request_message = RequestMessage(method, params=params)
-
-        future: asyncio.Future[ResponseData] = asyncio.Future()
-
-        def find_response(response_message: RoborockMessage) -> None:
-            try:
-                decoded = decode_rpc_response(response_message)
-            except RoborockException as ex:
-                _LOGGER.debug("Exception while decoding message (%s): %s", response_message, ex)
-                return
-            _LOGGER.debug("Received response (%s, request_id=%s)", self._name, decoded.request_id)
-            if decoded.request_id == request_message.request_id:
-                if decoded.api_error:
-                    future.set_exception(decoded.api_error)
-                else:
-                    future.set_result(decoded.data)
-
-        return await self._publisher.publish_and_wait(request_message, find_response, future)
-
-
-class MapRpcChannel(BaseV1RpcChannel):
-    """A V1 RPC channel that fetches and decodes map data."""
-
-    def __init__(
-        self,
-        publisher: RpcPublisher,
-        security_data: SecurityData,
-    ) -> None:
-        """Initialize the map RPC channel."""
-        self._publisher = publisher
-        self._decoder = create_map_response_decoder(security_data=security_data)
-
-    async def _send_raw_command(
-        self,
-        method: CommandType,
-        *,
-        params: ParamsType = None,
-    ) -> Any:
-        """Send a command and return a parsed response RoborockBase type."""
-        request_message = RequestMessage(method, params=params)
-
-        future: asyncio.Future[bytes] = asyncio.Future()
-
-        def find_response(response_message: RoborockMessage) -> None:
-            try:
-                decoded = self._decoder(response_message)
-            except RoborockException as ex:
-                _LOGGER.debug("Exception while decoding message (%s): %s", response_message, ex)
-                return
-            if decoded is None:
-                return
-            _LOGGER.debug("Received response (map), request_id=%s)", decoded.request_id)
-            if decoded.request_id == request_message.request_id:
-                future.set_result(decoded.data)
-
-        return await self._publisher.publish_and_wait(request_message, find_response, future)
-
-
 def create_mqtt_rpc_channel(mqtt_channel: MqttChannel, security_data: SecurityData) -> V1RpcChannel:
     """Create a V1 RPC channel using an MQTT channel."""
-    publisher = RpcPublisher(
+    return PayloadEncodedV1RpcChannel(
         "mqtt",
         mqtt_channel,
         lambda x: x.encode_message(RoborockMessageProtocol.RPC_REQUEST, security_data=security_data),
+        decode_rpc_response,
     )
-    return PayloadEncodedV1RpcChannel(publisher)
 
 
 def create_local_rpc_channel(local_channel: LocalChannel) -> V1RpcChannel:
     """Create a V1 RPC channel using a local channel."""
-    publisher = RpcPublisher(
-        "local", local_channel, lambda x: x.encode_message(RoborockMessageProtocol.GENERAL_REQUEST)
+    return PayloadEncodedV1RpcChannel(
+        "local",
+        local_channel,
+        lambda x: x.encode_message(RoborockMessageProtocol.GENERAL_REQUEST),
+        decode_rpc_response,
     )
-    return PayloadEncodedV1RpcChannel(publisher)
 
 
 def create_map_rpc_channel(
     mqtt_channel: MqttChannel,
     security_data: SecurityData,
-) -> MapRpcChannel:
+) -> V1RpcChannel:
     """Create a V1 RPC channel that fetches map data.
 
     This will prefer local channels when available, falling back to MQTT
     channels if not. If neither is available, an exception will be raised
     when trying to send a command.
     """
-    publisher = RpcPublisher(
+    return PayloadEncodedV1RpcChannel(
         "map",
         mqtt_channel,
         lambda x: x.encode_message(RoborockMessageProtocol.RPC_REQUEST, security_data=security_data),
+        create_map_response_decoder(security_data=security_data),
     )
-    return MapRpcChannel(publisher, security_data)

--- a/roborock/map/__init__.py
+++ b/roborock/map/__init__.py
@@ -1,0 +1,7 @@
+"""Module for Roborock map related data classes."""
+
+from .map_parser import MapParserConfig, ParsedMapData
+
+__all__ = [
+    "MapParserConfig",
+]

--- a/roborock/protocols/v1_protocol.py
+++ b/roborock/protocols/v1_protocol.py
@@ -187,7 +187,7 @@ def create_map_response_decoder(security_data: SecurityData) -> Callable[[Roboro
         header, body = message.payload[:24], message.payload[24:]
         [endpoint, _, request_id, _] = struct.unpack("<8s8sH6s", header)
         if not endpoint.decode().startswith(security_data.endpoint):
-            _LOGGER.debug("Received map response requested not made by this device, ignoring.")
+            _LOGGER.debug("Received map response not requested by this device, ignoring.")
             return None
         try:
             decrypted = Utils.decrypt_cbc(body, security_data.nonce)

--- a/tests/devices/test_v1_device.py
+++ b/tests/devices/test_v1_device.py
@@ -41,13 +41,19 @@ def mqtt_rpc_channel_fixture() -> AsyncMock:
     return AsyncMock()
 
 
+@pytest.fixture(autouse=True, name="map_rpc_channel")
+def map_rpc_channel_fixture() -> AsyncMock:
+    """Fixture to set up the channel for tests."""
+    return AsyncMock()
+
+
 @pytest.fixture(autouse=True, name="device")
 def device_fixture(channel: AsyncMock, rpc_channel: AsyncMock, mqtt_rpc_channel: AsyncMock) -> RoborockDevice:
     """Fixture to set up the device for tests."""
     return RoborockDevice(
         device_info=HOME_DATA.devices[0],
         channel=channel,
-        trait=v1.create(HOME_DATA.products[0], HOME_DATA, rpc_channel, mqtt_rpc_channel),
+        trait=v1.create(HOME_DATA.products[0], HOME_DATA, rpc_channel, mqtt_rpc_channel, map_rpc_channel=AsyncMock()),
     )
 
 

--- a/tests/devices/traits/v1/fixtures.py
+++ b/tests/devices/traits/v1/fixtures.py
@@ -47,5 +47,11 @@ def device_fixture(
     return RoborockDevice(
         device_info=HOME_DATA.devices[0],
         channel=channel,
-        trait=v1.create(HOME_DATA.products[0], HOME_DATA, mock_rpc_channel, mock_mqtt_rpc_channel, mock_map_rpc_channel),
+        trait=v1.create(
+            HOME_DATA.products[0],
+            HOME_DATA,
+            mock_rpc_channel,
+            mock_mqtt_rpc_channel,
+            mock_map_rpc_channel,
+        ),
     )

--- a/tests/devices/traits/v1/fixtures.py
+++ b/tests/devices/traits/v1/fixtures.py
@@ -33,11 +33,19 @@ def mqtt_rpc_channel_fixture() -> AsyncMock:
     return AsyncMock()
 
 
+@pytest.fixture(autouse=True, name="mock_map_rpc_channel")
+def map_rpc_channel_fixture() -> AsyncMock:
+    """Fixture to set up the channel for tests."""
+    return AsyncMock()
+
+
 @pytest.fixture(autouse=True, name="device")
-def device_fixture(channel: AsyncMock, mock_rpc_channel: AsyncMock, mock_mqtt_rpc_channel: AsyncMock) -> RoborockDevice:
+def device_fixture(
+    channel: AsyncMock, mock_rpc_channel: AsyncMock, mock_mqtt_rpc_channel: AsyncMock, mock_map_rpc_channel: AsyncMock
+) -> RoborockDevice:
     """Fixture to set up the device for tests."""
     return RoborockDevice(
         device_info=HOME_DATA.devices[0],
         channel=channel,
-        trait=v1.create(HOME_DATA.products[0], HOME_DATA, mock_rpc_channel, mock_mqtt_rpc_channel),
+        trait=v1.create(HOME_DATA.products[0], HOME_DATA, mock_rpc_channel, mock_mqtt_rpc_channel, mock_map_rpc_channel),
     )

--- a/tests/devices/traits/v1/test_map_content.py
+++ b/tests/devices/traits/v1/test_map_content.py
@@ -1,0 +1,39 @@
+"""Tests for the MapContentTrait."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from roborock.devices.device import RoborockDevice
+from roborock.devices.traits.v1.map_content import MapContentTrait
+from roborock.map.map_parser import ParsedMapData
+from roborock.roborock_typing import RoborockCommand
+
+
+@pytest.fixture
+def map_content_trait(device: RoborockDevice) -> MapContentTrait:
+    """Create a MapContentTrait instance with mocked dependencies."""
+    assert device.v1_properties
+    return device.v1_properties.map_content
+
+
+async def test_refresh_map_content_trait(
+    map_content_trait: MapContentTrait,
+    mock_map_rpc_channel: AsyncMock,
+) -> None:
+    """Test successfully getting and parsing map content."""
+    map_data = b"dummy_map_bytes"
+    mock_map_rpc_channel.send_command.return_value = map_data
+    mock_parsed_data = ParsedMapData(
+        image_content=b"dummy_image_content",
+        map_data=MagicMock(),
+    )
+
+    with patch("roborock.devices.traits.v1.map_content.MapParser.parse", return_value=mock_parsed_data) as mock_parse:
+        await map_content_trait.refresh()
+        mock_parse.assert_called_once_with(map_data)
+
+    assert map_content_trait.image_content == b"dummy_image_content"
+    assert map_content_trait.map_data is not None
+
+    mock_map_rpc_channel.send_command.assert_called_once_with(RoborockCommand.GET_MAP_V1)

--- a/tests/protocols/test_v1_protocol.py
+++ b/tests/protocols/test_v1_protocol.py
@@ -209,7 +209,7 @@ def test_create_map_response_decoder_invalid_endpoint(caplog: pytest.LogCaptureF
 
     decoder = create_map_response_decoder(SECURITY_DATA)
     assert decoder(message) is None
-    assert "Received map response requested not made by this device, ignoring." in caplog.text
+    assert "Received map response not requested by this device, ignoring." in caplog.text
 
 
 def test_create_map_response_decoder_invalid_payload():


### PR DESCRIPTION
Add a v1 device trait for map contents

This uses the map parser library to return an image and the parsed data from from get v1 maps API. Internally, a new RPC channel is added that is configured to properly encode and parse map responses. Two new CLI options are added for exercising the image content and map metadata functionality.
