### PR TITLE
fix: return in finally

### DIFF
--- a/roborock/version_1_apis/roborock_client_v1.py
+++ b/roborock/version_1_apis/roborock_client_v1.py
@@ -228,7 +228,8 @@ class RoborockClientV1(RoborockClient, ABC):
                         final_record.square_meter_area += (
                             rec.square_meter_area if rec.square_meter_area is not None else 0
                         )
-                finally:
+                except Exception:
+                    # Return final record when an exception occurred
                     return final_record
             # There are still a few unknown variables in this.
             begin, end, duration, area = unpack_list(record, 4)


### PR DESCRIPTION
Using `return` in a finally clauses is a SyntaxWarning in Python 3.14.