### PR TITLE
chore: fix test warning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from asyncio import Protocol
 from collections.abc import AsyncGenerator, Callable, Generator
 from queue import Queue
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from aioresponses import aioresponses
@@ -360,12 +360,12 @@ class FakeChannel:
         self.publish = AsyncMock(side_effect=self._publish)
         self.subscribe = AsyncMock(side_effect=self._subscribe)
         self.connect = AsyncMock(side_effect=self._connect)
-        self.close = AsyncMock(side_effect=self._close)
+        self.close = MagicMock(side_effect=self._close)
 
     async def _connect(self) -> None:
         self._is_connected = True
 
-    async def _close(self) -> None:
+    def _close(self) -> None:
         self._is_connected = False
 
     @property

--- a/tests/devices/test_v1_channel.py
+++ b/tests/devices/test_v1_channel.py
@@ -174,7 +174,7 @@ async def test_v1_channel_mqtt_disconnected(
     mock_local_channel.connect.assert_called_once()
 
     # Simulate an MQTT disconnection where the channel is not healthy
-    await mock_mqtt_channel.close()
+    mock_mqtt_channel.close()
 
     # Verify properties
     assert not v1_channel.is_mqtt_connected


### PR DESCRIPTION
```py
tests/devices/test_v1_channel.py::test_v1_channel_command_encoding_validation
  /.../python-roborock/roborock/devices/v1_channel.py:233:
      RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self._local_channel.close()
```

Close is a normal function, not async.
https://github.com/Python-roborock/python-roborock/blob/e9ba1e3be3ae9119266225190227c0de6dec16e6/roborock/devices/local_channel.py#L73-L80