### PR TITLE
feat(web_api): add inbox message retrieval

### DIFF
--- a/roborock/data/containers.py
+++ b/roborock/data/containers.py
@@ -349,6 +349,23 @@ class HomeDataScene(RoborockBase):
 
 
 @dataclass
+class InboxMessage(RoborockBase):
+    """A single user/device inbox message (`/user/inbox`)."""
+
+    id: int | None = None
+    trigger: str | None = None
+    """Message category, e.g. NOTIFICATION, WARNING, SYSTEM, MARKETING, SHARE."""
+    duid: str | None = None
+    """Device this message relates to (None for account-level messages)."""
+    subject: str | None = None
+    content: str | None = None
+    extra: str | None = None
+    """Raw JSON string with action/templateId metadata."""
+    read: bool | None = None
+    create_time: str | None = None
+
+
+@dataclass
 class HomeDataSchedule(RoborockBase):
     id: int
     cron: str

--- a/roborock/web_api.py
+++ b/roborock/web_api.py
@@ -15,7 +15,7 @@ from aiohttp import ContentTypeError, FormData
 from pyrate_limiter import Duration, Limiter, Rate
 
 from roborock import HomeDataSchedule
-from roborock.data import HomeData, HomeDataRoom, HomeDataScene, ProductResponse, RRiot, UserData
+from roborock.data import HomeData, HomeDataRoom, HomeDataScene, InboxMessage, ProductResponse, RRiot, UserData
 from roborock.exceptions import (
     RoborockAccountDoesNotExist,
     RoborockException,
@@ -607,6 +607,42 @@ class RoborockApiClient:
             return [HomeDataScene.from_dict(scene) for scene in scenes]
         else:
             raise RoborockException("scene_response result was an unexpected type")
+
+    async def get_inbox_messages(
+        self,
+        user_data: UserData,
+        message_type: str = "NOTIFICATION",
+        device_id: str | None = None,
+        offset: int = 0,
+        limit: int = 20,
+    ) -> list[InboxMessage]:
+        """Get inbox messages of a given type, newest first.
+
+        ``message_type`` is one of NOTIFICATION/WARNING (device-scoped, require
+        ``device_id``) or SYSTEM/MARKETING/SHARE (account-scoped). rriot API host with
+        Hawk auth.
+        """
+        rriot = user_data.rriot
+        if rriot is None:
+            raise RoborockException("rriot is none")
+        if rriot.r.a is None:
+            raise RoborockException("Missing field 'a' in rriot reference")
+        path = "/user/inbox"
+        params = {"offset": str(offset), "limit": str(limit), "type": message_type}
+        if device_id is not None:
+            params["duid"] = device_id
+        inbox_request = PreparedRequest(
+            rriot.r.a,
+            self.session,
+            {
+                "Authorization": _get_hawk_authentication(rriot, path, params=params),
+            },
+        )
+        inbox_response = await inbox_request.request("get", path, params=params)
+        if not inbox_response or not inbox_response.get("success"):
+            raise RoborockException(inbox_response)
+        result = inbox_response.get("result") or {}
+        return [InboxMessage.from_dict(message) for message in result.get("list", [])]
 
     async def execute_scene(self, user_data: UserData, scene_id: int) -> None:
         rriot = user_data.rriot

--- a/tests/fixtures/web_api_fixtures.py
+++ b/tests/fixtures/web_api_fixtures.py
@@ -137,6 +137,41 @@ def mock_rest_fixture(skip_rate_limit: Any, home_data: dict[str, Any]) -> aiores
             status=200,
             payload={"api": None, "code": 200, "result": None, "status": "ok", "success": True},
         )
+        mocked.get(
+            re.compile(r"https://.*roborock\.com/user/inbox(\?.*)?$"),
+            status=200,
+            payload={
+                "api": None,
+                "result": {
+                    "total": 2,
+                    "list": [
+                        {
+                            "id": 2458218464,
+                            "trigger": "NOTIFICATION",
+                            "duid": "abc123",
+                            "subject": "Roborock Q7",
+                            "content": "Battery low. Please charge.",
+                            "extra": '{"templateId":34}',
+                            "read": False,
+                            "createTime": "2026-05-29T14:03:16.542+00:00",
+                        },
+                        {
+                            "id": 2458212274,
+                            "trigger": "NOTIFICATION",
+                            "duid": "abc123",
+                            "subject": "Roborock Q7",
+                            "content": "Cleaning complete. Returning to dock.",
+                            "extra": '{"templateId":24}',
+                            "read": True,
+                            "createTime": "2026-05-23T06:08:39.687+00:00",
+                        },
+                    ],
+                },
+                "status": "ok",
+                "success": True,
+            },
+            repeat=True,
+        )
         mocked.post(
             re.compile(r"https://.*iot\.roborock\.com/api/v4/email/code/send.*"),
             status=200,

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -81,6 +81,18 @@ async def test_get_scenes():
     ]
 
 
+async def test_get_inbox_messages():
+    """Test that we can fetch device inbox messages."""
+    api = RoborockApiClient(username="test_user@gmail.com")
+    ud = await api.pass_login("password")
+    messages = await api.get_inbox_messages(ud, "NOTIFICATION", device_id="abc123")
+    assert len(messages) == 2
+    assert messages[0].content == "Battery low. Please charge."
+    assert messages[0].read is False
+    assert messages[0].trigger == "NOTIFICATION"
+    assert messages[1].read is True
+
+
 async def test_execute_scene(mock_rest):
     """Test that we can execute a scene"""
     api = RoborockApiClient(username="test_user@gmail.com")


### PR DESCRIPTION
## Summary

Adds retrieval of the user/device **inbox** to `RoborockApiClient`. This is the
app's server-side, localized event history for a device (cleaning finished,
battery low, ...) — richer context than the raw MQTT status. Part of #739.

`GET /user/inbox` on the rriot API host (`api-eu.roborock.com`) with Hawk auth.

## What's added

- `InboxMessage` dataclass (`id`, `trigger`, `duid`, `subject`, `content`,
  `extra`, `read`, `create_time`).
- `get_inbox_messages(user_data, message_type="NOTIFICATION", duid=None,
  offset=0, limit=20)` -> list of `InboxMessage`, newest first.

## Message types

- `NOTIFICATION` / `WARNING` — device-scoped (require `duid`).
- `SYSTEM` / `MARKETING` / `SHARE` — account-scoped.

`extra` carries a raw JSON string with action/`templateId` metadata; the
`templateId` is a language-independent message-type code (more stable than the
localized text).

## Verification

- Logged against a real account (read-only) — returned real device events.
- New unit test + aioresponses fixture; `ruff` clean.
