### PR TITLE
feat(q7): add set_button_lights trait method

### DIFF
--- a/roborock/devices/traits/b01/q7/__init__.py
+++ b/roborock/devices/traits/b01/q7/__init__.py
@@ -154,6 +154,10 @@ class Q7PropertiesApi(Trait):
             },
         )
 
+    async def set_button_light(self, enabled: bool) -> None:
+        """Enable or disable the button/panel lights."""
+        await self.set_prop(RoborockB01Props.LIGHT_MODE, int(enabled))
+
     async def start_clean(self) -> None:
         """Start cleaning."""
         await self.send(

--- a/tests/devices/traits/b01/q7/test_init.py
+++ b/tests/devices/traits/b01/q7/test_init.py
@@ -172,6 +172,26 @@ async def test_q7_api_set_do_not_disturb_invalid_time(
 
 
 @pytest.mark.parametrize(
+    ("enabled", "expected_code"),
+    [(True, 1), (False, 0)],
+)
+async def test_q7_api_set_button_light(
+    enabled: bool,
+    expected_code: int,
+    q7_api: Q7PropertiesApi,
+    fake_channel: FakeQ7Channel,
+):
+    """Test toggling the button/panel lights."""
+    fake_channel.response_queue.append({"result": "ok"})
+    await q7_api.set_button_light(enabled)
+
+    assert len(fake_channel.published_commands) == 1
+    command, params = fake_channel.published_commands[0]
+    assert command == RoborockB01Q7Methods.SET_PROP
+    assert params == {RoborockB01Props.LIGHT_MODE: expected_code}
+
+
+@pytest.mark.parametrize(
     ("mode", "expected_code"),
     [
         (CleanTypeMapping.VACUUM, 0),


### PR DESCRIPTION
## Summary

Adds `set_button_lights(enabled)` to the Q7 (B01) trait, toggling the panel /
button lights via `prop.set` for `RoborockB01Props.LIGHT_MODE` (`0`/`1`).
Part of #739.

## Verification

- Getter + setter verified live on a Roborock Q7 L5+.
- New parametrized unit test (on/off); `ruff` clean.
