### PR TITLE
fix: replace __init__ with __all__ in a01 traits

### DIFF
--- a/roborock/devices/traits/a01/__init__.py
+++ b/roborock/devices/traits/a01/__init__.py
@@ -53,7 +53,7 @@ from roborock.devices.traits import Trait
 from roborock.devices.transport.mqtt_channel import MqttChannel
 from roborock.roborock_message import RoborockDyadDataProtocol, RoborockZeoProtocol
 
-__init__ = [
+__all__ = [
     "DyadApi",
     "ZeoApi",
 ]


### PR DESCRIPTION
## Description
Fix typo in `roborock/devices/traits/a01/__init__.py` where `__init__` was used instead of `__all__`.