### PR TITLE
fix: name B01 Q7 code 2103 and document dock dust-collection state fields

### DIFF
--- a/roborock/data/b01_q7/b01_q7_code_mappings.py
+++ b/roborock/data/b01_q7/b01_q7_code_mappings.py
@@ -290,7 +290,12 @@ class B01Fault(RoborockModeEnum):
     # charging.
     F_2101 = ("fault_2101", 2101)
     F_2102 = ("cleaning_complete", 2102)  # Cleaning completed. Returning to the dock.
-    F_2103 = ("fault_2103", 2103)
+    F_2103 = (
+        "cleaning_complete_docked",
+        2103,
+    )  # Task finished; robot docked (follows 2102 once docking and any auto-empty complete). hw-confirmed
+    # (Q7 M5+): appears immediately after a completed clean's dock + dust collection and persists while
+    # docked-idle; not an error.
     F_2104 = ("fault_2104", 2104)
     F_2105 = ("fault_2105", 2105)
     F_2108 = ("fault_2108", 2108)

--- a/roborock/data/b01_q7/b01_q7_code_mappings.py
+++ b/roborock/data/b01_q7/b01_q7_code_mappings.py
@@ -293,9 +293,8 @@ class B01Fault(RoborockModeEnum):
     F_2103 = (
         "cleaning_complete_docked",
         2103,
-    )  # Task finished; robot docked (follows 2102 once docking and any auto-empty complete). hw-confirmed
-    # (Q7 M5+): appears immediately after a completed clean's dock + dust collection and persists while
-    # docked-idle; not an error.
+    )  # Task finished and robot docked. Follows 2102 once docking and any auto-empty complete; persists
+    # while docked-idle. Not an error (hw-confirmed on a Q7 M5+).
     F_2104 = ("fault_2104", 2104)
     F_2105 = ("fault_2105", 2105)
     F_2108 = ("fault_2108", 2108)

--- a/roborock/data/b01_q7/b01_q7_containers.py
+++ b/roborock/data/b01_q7/b01_q7_containers.py
@@ -137,11 +137,11 @@ class B01Props(RoborockBase):
     custom_type: int | None = None
     sound: int | None = None
     work_mode: WorkModeMapping | None = None
-    station_act: int | None = None
+    station_act: int | None = None  # dock activity; 3 while collecting dust, 0 idle. hw-confirmed (Q7 M5+)
     charge_state: int | None = None
     current_map_id: int | None = None
     map_num: int | None = None
-    dust_action: int | None = None
+    dust_action: int | None = None  # 1 while the dock is collecting dust; read-only (prop.set rejected, code 1)
     quiet_is_open: int | None = None
     quiet_begin_time: int | None = None
     quiet_end_time: int | None = None


### PR DESCRIPTION
Small follow-up to #919, based on a live end-to-end capture of a completed clean → docking → auto-empty on a Q7 M5+ (`roborock.vacuum.sc05`, fw 03.01.80). Full evidence timeline is in [this #919 comment](https://github.com/Python-roborock/python-roborock/pull/919#issuecomment-5308270383).

**Changes:**
- `B01Fault.F_2103`: placeholder `fault_2103` → `cleaning_complete_docked`. Observed appearing the moment a completed clean's dock + dust collection finished, persisting while docked-idle; it follows 2102 (`cleaning_complete`, seen exactly at completion/return) and is a benign task notification, not an error.
- `B01Props.station_act` / `dust_action`: documented hw-observed dock-emptying semantics — `station_act=3` + `dust_action=1` during the ~30s auto-empty cycle, both 0 otherwise; `dust_action` is read-only (`prop.set` rejected with code 1).

These two fields are enough for a "dock emptying" state/sensor downstream; the clean record's `record_dust_num` additionally tracks empties per clean.

Left 2105 as a placeholder — I've observed it while long-idle on the dock (possibly a later idle/charged notice) but don't have a clean state transition for it yet; happy to capture more if useful.