### PR TITLE
fix: update pypi-publish so that it will properly build to pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         changelog: true
 
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.13.0
+      uses: pypa/gh-action-pypi-publish@v1.14.2
       # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
       # See https://github.com/actions/runner/issues/1173
       if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
fixes: #924 (I think)

Issue with the manifests for the older version and how it works with the newer (unpinned) versions of hatchling.