### PR TITLE
docs(q7): document live map pushes and cover them in tests

### DIFF
--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -19,6 +19,7 @@ Cloud and Network.
         *   Use `device.b01_q10_properties.vacuum` to access vacuum commands (start, pause, stop, dock, empty dustbin, set clean mode, set fan level).
         *   Use `device.b01_q10_properties.command.send()` for raw DP commands.
     *   **Vacuums (B01 Q7)**: Use `device.b01_q7_properties` for Q7 series devices.
+        *   The device streams full map frames on its own while cleaning, so the rendered map stays current without polling or a heartbeat. Register `device.b01_q7_properties.map_content.add_update_listener(cb)` and read `image_content` / `map_data` when notified.
 
 ## Background: Understanding Device Protocols
 

--- a/roborock/devices/traits/b01/q7/map_content.py
+++ b/roborock/devices/traits/b01/q7/map_content.py
@@ -6,6 +6,10 @@ This intentionally mirrors the v1 `MapContentTrait` contract:
 - fields `image_content`, `map_data`, and `raw_api_response` are then readable
 
 For B01/Q7 devices, the underlying raw map payload is retrieved via `MapTrait`.
+
+Q7 devices additionally stream map frames unprompted while cleaning; those arrive
+through `update_from_push()`, which keeps the same cached fields current and
+notifies registered update listeners.
 """
 
 import asyncio

--- a/tests/devices/traits/b01/q7/test_map_content.py
+++ b/tests/devices/traits/b01/q7/test_map_content.py
@@ -119,8 +119,11 @@ async def test_q7_map_content_updates_from_push(
         fake_channel.map_push_callback(pushed_payload)
 
     assert q7_api.map_content.image_content == b"pngbytes"
+    assert q7_api.map_content.map_data is dummy_map_data
     assert q7_api.map_content.raw_api_response == pushed_payload
     assert updates == [True]
+    # No RPC was needed to get here.
+    assert fake_channel.published_commands == []
 
     await q7_api.close()
     assert fake_channel.map_push_callback is None


### PR DESCRIPTION
Follow-up on the Q7 (B01) live map pushes: the runtime behaviour is unchanged, this only makes the push path discoverable and pins it down in tests.

### Docs

`MapContentTrait`'s module docstring describes a pure pull contract — `refresh()` does I/O, `parse_map_content()` reparses, fields "are then readable". That no longer holds: `update_from_push()` writes the same cached fields from the MQTT receive callback and notifies listeners, so `image_content` / `map_data` / `raw_api_response` can change without the reader calling anything. The docstring now says so.

`docs/DEVICES.md` listed only `device.b01_q7_properties` under B01 Q7, with no hint that maps arrive on their own. A consumer reading it finds just the pull API and builds a polling loop for something the device streams by itself — so the entry point (`map_content.add_update_listener(cb)`) and the fields to read are now named, the way the Q10 section already does for its commands.

### Tests

Two gaps in `test_q7_map_content_updates_from_push`:

- `map_data` was not asserted, even though it carries the live robot pose and cleaning path. `_parse_and_store()` sets three fields; dropping the `map_data` assignment left the test green. Asserted by identity, since two empty `MapData` instances compare equal and equality would also accept a stale or copied object.
- Nothing asserted that the push path publishes no command. That is the actual claim of the feature: `refresh()` needs `map_trait.current_map_id` and costs two round trips (the refresh tests assert `len(published_commands) == 2`), while a push needs neither. Without the assertion the test would still pass if `update_from_push()` or `start()` started issuing RPCs.

`uv run pytest tests/devices/traits/b01/q7 tests/devices/rpc/test_b01_q7_channel.py` → 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
