### PR TITLE
fix: keep Q10 map vectors stable during live updates

### DIFF
--- a/roborock/map/b01_q10_render.py
+++ b/roborock/map/b01_q10_render.py
@@ -185,8 +185,10 @@ def _vector_calibration(
     trace_calibration: GridCalibration | None,
 ) -> GridCalibration | None:
     """Derive the 5 mm erase/restriction-vector transform."""
-    y_sign = trace_calibration.y_sign if trace_calibration is not None else 1
-    if calibration := _calibration_from_header_metadata(packet, y_sign=y_sign):
+    # Header vectors share the map packet's fixed top-down coordinate frame.
+    # A trace fit may choose either Y orientation, but that must not move saved
+    # erase/restriction geometry when a cleaning trace appears or disappears.
+    if calibration := _calibration_from_header_metadata(packet):
         return calibration
     if trace_calibration is None:
         return None

--- a/tests/map/test_b01_q10_render.py
+++ b/tests/map/test_b01_q10_render.py
@@ -225,6 +225,14 @@ def test_render_applies_erase_zones_from_header_without_trace() -> None:
     assert render != base
 
 
+def test_header_vector_calibration_is_independent_of_trace_orientation() -> None:
+    """A live trace cannot flip saved erase/restriction geometry vertically."""
+    packet = replace(_packet(), header_calibration=HEADER)
+    mirrored_trace = replace(TRACE_CALIBRATION, y_sign=-1)
+
+    assert _vector_calibration(packet, mirrored_trace) == VECTOR_CALIBRATION
+
+
 def test_render_partial_erase() -> None:
     """An erase rectangle only blanks the cells it covers, leaving the rest."""
     packet, trace = _calibrated_inputs()


### PR DESCRIPTION
## Summary

- Keep header-derived Q10 erase and restriction vectors in the map packet's fixed top-down coordinate frame.
- Prevent an independently fitted cleaning trace from vertically flipping saved map geometry.
- Add a regression test for a trace whose fitted Y orientation differs from the map frame.

## Root cause

Q10 map-header vectors use a stable 5 mm coordinate frame. The renderer copied the independently fitted 2.5 mm cleaning trace's Y orientation into the header-derived vector calibration. When that fitted trace orientation changed, a saved erase rectangle could move to another part of the raster and produce a large transparent area.

The trace-derived fallback remains unchanged for packets without usable header calibration.

Related to #767.

## Testing

- `uv run pytest` — 963 tests and 89 snapshots passed
- `uv run pre-commit run --all-files` — passed
- Tested through Home Assistant with a physical Q10 S5+ across cold start, integration reload, live cleaning updates, and return-to-dock