### PR TITLE
fix: request Q10 maps without starting cleaning

### DIFF
--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -594,9 +594,9 @@ async def maps(ctx, device_id: str):
     await _display_v1_trait(context, device_id, lambda v1: v1.maps)
 
 
-# The Q10 publishes its map asynchronously after a dpMultiMap list/get request.
-# Firmware throttles pushes to ~once per 60-70s, so rapid re-requests may not be
-# answered immediately. This bounds how long a one-shot CLI command waits.
+# The Q10 publishes its current map asynchronously after a REQUEST_DPS. Firmware
+# throttles pushes to ~once per 60-70s, so rapid re-requests may not be answered
+# immediately. This bounds how long a one-shot CLI command waits.
 _Q10_MAP_PUSH_TIMEOUT = 30.0
 
 
@@ -609,10 +609,9 @@ async def _await_q10_map_push(
 ) -> bool:
     """Request Q10 map content and wait for usable map-trait state.
 
-    A Q10 needs a saved-map ID before it can request content. The map list and
-    content have independent refresh schedules, so the list is requested only
-    when no ID is stored. The content then arrives as a later ``MAP_RESPONSE``
-    and is published through the standard trait update interface.
+    The read-only ``REQUEST_DPS`` request returns immediately; current map
+    content arrives as a later ``MAP_RESPONSE`` and is published through the
+    standard trait update interface.
     """
     loop = asyncio.get_running_loop()
     updated: asyncio.Future[None] = loop.create_future()
@@ -624,20 +623,6 @@ async def _await_q10_map_push(
     unsub = properties.map.add_update_listener(on_update)
     try:
         async with asyncio.timeout(timeout):
-            if properties.maps.current_map_id is None:
-                map_list_updated: asyncio.Future[None] = loop.create_future()
-
-                def on_map_list_update() -> None:
-                    if properties.maps.current_map_id is not None and not map_list_updated.done():
-                        map_list_updated.set_result(None)
-
-                unsub_maps = properties.maps.add_update_listener(on_map_list_update)
-                try:
-                    await properties.maps.refresh()
-                    if properties.maps.current_map_id is None:
-                        await map_list_updated
-                finally:
-                    unsub_maps()
             await properties.map.refresh()
             await updated
         return True

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -7,10 +7,10 @@ Map-related state arrives on three independent streams:
 * restricted zones, virtual walls and dock state arrive as ordinary DPS values.
 
 ``MapDpsTrait`` owns the low-level map-specific DPS read model.
-``MapContentTrait`` uses a stored ID from ``MapsTrait`` only when it requests
-content. It combines the latest map and trace packets with the map DPS state
-through the pure functions in :mod:`roborock.map.b01_q10_render`. Map-list
-updates do not refresh content.
+``MapContentTrait`` requests a current-map push through ``REQUEST_DPS`` and
+combines the latest map and trace packets with the map DPS state through the
+pure functions in :mod:`roborock.map.b01_q10_render`. Saved-map list/detail
+operations remain on ``MapsTrait``.
 """
 
 import logging
@@ -107,20 +107,13 @@ class MapContentTrait(TraitUpdateListener):
         self._map_dps.add_update_listener(self._map_dps_updated)
 
     async def refresh(self) -> None:
-        """Request content for the first map in the latest saved-map list."""
-        if (map_id := self._maps.current_map_id) is None:
-            raise RoborockException("Cannot request Q10 map content before the map list is available")
-        # Map lists and map content can change at different times. Reuse the
-        # stored ID so a content refresh does not also refresh the list.
-        await self._command.send(
-            B01_Q10_DP.COMMON,
-            {
-                str(B01_Q10_DP.MULTI_MAP.code): {
-                    "op": "get",
-                    "id": map_id,
-                }
-            },
-        )
+        """Request a safe asynchronous current-map/status push.
+
+        Some ss07 firmware treats ``dpMultiMap op:get`` as an active
+        cleaning/relocation command. ``REQUEST_DPS`` is the device's read-only
+        current-map request and does not depend on a saved-map ID.
+        """
+        await self._command.send(B01_Q10_DP.REQUEST_DPS, params={})
 
     @property
     def image_content(self) -> bytes | None:

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -140,34 +140,6 @@ class _FakeQ10PropertiesWithTrace(_FakeQ10Properties):
         self.map.refresh = refresh_map  # type: ignore[method-assign]
 
 
-class _FakeQ10PropertiesWithoutMapId:
-    def __init__(self) -> None:
-        command = cast(CommandTrait, Mock(spec=CommandTrait))
-        self.maps = MapsTrait(command)
-        self.map = MapContentTrait(MapDpsTrait(), self.maps, command)
-        self.maps_refresh_count = 0
-        self.map_refresh_count = 0
-
-        async def refresh_maps() -> None:
-            self.maps_refresh_count += 1
-            self.maps.update_from_dps(
-                {
-                    B01_Q10_DP.MULTI_MAP: {
-                        "data": [{"id": "12345"}],
-                        "op": "list",
-                        "result": 1,
-                    }
-                }
-            )
-
-        async def refresh_map() -> None:
-            self.map_refresh_count += 1
-            self.map.update_from_trace_packet(parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes()))
-
-        self.maps.refresh = refresh_maps  # type: ignore[method-assign]
-        self.map.refresh = refresh_map  # type: ignore[method-assign]
-
-
 async def test_await_q10_map_push_waits_for_fresh_update() -> None:
     """A cached trace alone is not treated as a successful new map push."""
     properties = _FakeQ10Properties()
@@ -194,21 +166,6 @@ async def test_await_q10_map_push_returns_true_after_update() -> None:
 
     assert got_trace is True
     assert len(properties.map.path) == 14
-
-
-async def test_await_q10_map_push_requests_map_list_only_on_first_use() -> None:
-    """Content gets the list first only when no stored map ID is available."""
-    properties = _FakeQ10PropertiesWithoutMapId()
-
-    got_trace = await _await_q10_map_push(
-        cast(Q10PropertiesApi, properties),
-        lambda: bool(properties.map.path),
-        timeout=0.01,
-    )
-
-    assert got_trace is True
-    assert properties.maps_refresh_count == 1
-    assert properties.map_refresh_count == 1
 
 
 async def test_await_q10_map_push_can_fall_back_to_cached_map_on_timeout() -> None:
@@ -286,7 +243,7 @@ async def test_subscribe_loop_routes_trace_push(
     assert q10_api.map.robot_position is not None
 
 
-async def test_map_list_and_content_refresh_are_independent(
+async def test_map_list_and_current_content_refresh_are_independent(
     q10_api: Q10PropertiesApi,
     mock_channel: FakeB01Q10Channel,
     message_queue: asyncio.Queue[Q10Message],
@@ -320,15 +277,7 @@ async def test_map_list_and_content_refresh_are_independent(
 
     await q10_api.map.refresh()
 
-    assert mock_channel.published_commands[1] == (
-        B01_Q10_DP.COMMON,
-        {
-            str(B01_Q10_DP.MULTI_MAP.code): {
-                "op": "get",
-                "id": "12345",
-            }
-        },
-    )
+    assert mock_channel.published_commands[1] == (B01_Q10_DP.REQUEST_DPS, {})
     assert q10_api.maps.current_map_id == "12345"
 
 
@@ -355,10 +304,14 @@ async def test_empty_map_list_does_not_request_content(
     assert mock_channel.published_commands == []
 
 
-async def test_map_content_refresh_requires_stored_map_id(q10_api: Q10PropertiesApi) -> None:
-    """Content cannot be requested until the map list supplies an ID."""
-    with pytest.raises(RoborockException, match="map list is available"):
-        await q10_api.map.refresh()
+async def test_map_content_refresh_does_not_require_stored_map_id(
+    q10_api: Q10PropertiesApi,
+    mock_channel: FakeB01Q10Channel,
+) -> None:
+    """Current-map refresh is read-only and independent of saved-map state."""
+    await q10_api.map.refresh()
+
+    assert mock_channel.published_commands == [(B01_Q10_DP.REQUEST_DPS, {})]
 
 
 async def test_map_content_refresh_requests_are_not_rate_limited(q10_api: Q10PropertiesApi) -> None:


### PR DESCRIPTION
Related to #767. Built on the stable Q10 vector calibration merged in #932 and released in `7.2.1`.

## Summary

- request the current Q10 map with the read-only `REQUEST_DPS` command
- remove the saved-map-list dependency from current-map refreshes
- keep the one-shot CLI wait bounded around the asynchronous map push

## Why

On observed `roborock.vacuum.ss07` firmware, `dpMultiMap op:get` is not a safe read: it can initiate cleaning or relocation. `REQUEST_DPS` requests the current status/map push without moving or starting the robot and does not require a saved-map ID.

## Validation

- `uv run pytest -q`: **965 passed**, **92 snapshots passed**
- `pre-commit run --all-files`: passed, including Ruff, mypy, codespell, structured-file checks, and private-key detection
- `uv build`: passed for both sdist and wheel
- validated repeatedly on a physical Q10 S5+; current-map pushes arrived without cleaning or relocation and the robot remained docked

No credentials, identifiers, room labels, floorplans, packet captures, or private fixtures are included.

The archive parser, archive traits, obstacles, and current-room work from the earlier revision have been moved to separately validated follow-up branches and will be submitted sequentially as focused PRs.

## Reviewer guide

1. `MapContentTrait.refresh`: the command change
2. `_await_q10_map_push`: removal of the map-list prerequisite
3. map-trait tests: exact command and map-list independence
