### PR TITLE
feat: add Q10 map management controls

### DIFF
--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -594,9 +594,9 @@ async def maps(ctx, device_id: str):
     await _display_v1_trait(context, device_id, lambda v1: v1.maps)
 
 
-# The Q10 publishes its map asynchronously after a dpMultiMap list/get request.
-# Firmware throttles pushes to ~once per 60-70s, so rapid re-requests may not be
-# answered immediately. This bounds how long a one-shot CLI command waits.
+# The Q10 publishes its current map asynchronously after a REQUEST_DPS. Firmware
+# throttles pushes to ~once per 60-70s, so rapid re-requests may not be answered
+# immediately. This bounds how long a one-shot CLI command waits.
 _Q10_MAP_PUSH_TIMEOUT = 30.0
 
 
@@ -609,10 +609,9 @@ async def _await_q10_map_push(
 ) -> bool:
     """Request Q10 map content and wait for usable map-trait state.
 
-    A Q10 needs a saved-map ID before it can request content. The map list and
-    content have independent refresh schedules, so the list is requested only
-    when no ID is stored. The content then arrives as a later ``MAP_RESPONSE``
-    and is published through the standard trait update interface.
+    The read-only ``REQUEST_DPS`` request returns immediately; current map
+    content arrives as a later ``MAP_RESPONSE`` and is published through the
+    standard trait update interface.
     """
     loop = asyncio.get_running_loop()
     updated: asyncio.Future[None] = loop.create_future()
@@ -624,20 +623,6 @@ async def _await_q10_map_push(
     unsub = properties.map.add_update_listener(on_update)
     try:
         async with asyncio.timeout(timeout):
-            if properties.maps.current_map_id is None:
-                map_list_updated: asyncio.Future[None] = loop.create_future()
-
-                def on_map_list_update() -> None:
-                    if properties.maps.current_map_id is not None and not map_list_updated.done():
-                        map_list_updated.set_result(None)
-
-                unsub_maps = properties.maps.add_update_listener(on_map_list_update)
-                try:
-                    await properties.maps.refresh()
-                    if properties.maps.current_map_id is None:
-                        await map_list_updated
-                finally:
-                    unsub_maps()
             await properties.map.refresh()
             await updated
         return True

--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -597,12 +597,13 @@ async def maps(ctx, device_id: str):
 # The Q10 publishes its current map asynchronously after a REQUEST_DPS. Firmware
 # throttles pushes to ~once per 60-70s, so rapid re-requests may not be answered
 # immediately. This bounds how long a one-shot CLI command waits.
-_Q10_MAP_PUSH_TIMEOUT = 30.0
+_Q10_MAP_PUSH_TIMEOUT = 75.0
 
 
 async def _await_q10_map_push(
     properties: Q10PropertiesApi,
     predicate: Callable[[], bool],
+    revision: Callable[[], int],
     *,
     timeout: float = _Q10_MAP_PUSH_TIMEOUT,
     allow_cached_on_timeout: bool = False,
@@ -615,9 +616,10 @@ async def _await_q10_map_push(
     """
     loop = asyncio.get_running_loop()
     updated: asyncio.Future[None] = loop.create_future()
+    initial_revision = revision()
 
     def on_update() -> None:
-        if predicate() and not updated.done():
+        if revision() > initial_revision and predicate() and not updated.done():
             updated.set_result(None)
 
     unsub = properties.map.add_update_listener(on_update)
@@ -647,6 +649,7 @@ async def map_image(ctx, device_id: str, output_file: str):
         await _await_q10_map_push(
             properties,
             lambda: properties.map.image_content is not None,
+            lambda: properties.map.map_revision,
             allow_cached_on_timeout=True,
         )
         image_content = properties.map.image_content
@@ -695,8 +698,8 @@ async def map_data(ctx, device_id: str, include_path: bool):
 async def q10_position(ctx, device_id: str, include_path: bool):
     """Get the current Q10 robot position and live cleaning path.
 
-    The Q10 only streams its position/path while it is actively cleaning, so this
-    will report that no live trace is available for an idle/docked robot.
+    The Q10 normally streams position/path while it is actively cleaning, so an
+    idle device may report that no fresh live trace is available.
     """
     context: RoborockContext = ctx.obj
     device_manager = await context.get_device_manager()
@@ -708,9 +711,10 @@ async def q10_position(ctx, device_id: str, include_path: bool):
     got_trace = await _await_q10_map_push(
         properties,
         lambda: bool(properties.map.path),
+        lambda: properties.map.trace_revision,
     )
     if not got_trace:
-        click.echo("No live trace available (the robot only reports position while cleaning).")
+        click.echo("No fresh live trace available.")
         return
     map_trait = properties.map
     position = map_trait.robot_position
@@ -873,6 +877,7 @@ async def rooms(ctx, device_id: str):
         await _await_q10_map_push(
             properties,
             lambda: properties.map.image_content is not None,
+            lambda: properties.map.map_revision,
             allow_cached_on_timeout=True,
         )
         click.echo(dump_json({room.id: room.name for room in properties.map.rooms}))

--- a/roborock/data/b01_q10/b01_q10_containers.py
+++ b/roborock/data/b01_q10/b01_q10_containers.py
@@ -28,6 +28,45 @@ from .b01_q10_code_mappings import (
     YXWaterLevel,
 )
 
+_ROBOROCK_COORDINATE_OFFSET_MM = 25_500
+_Q10_VECTOR_UNIT_MM = 5
+
+
+@dataclass(frozen=True)
+class Q10RoborockPoint:
+    """A point in the common Roborock millimetre coordinate space."""
+
+    x: int
+    y: int
+
+    @classmethod
+    def from_vector(cls, x: int, y: int) -> "Q10RoborockPoint":
+        """Convert Q10 vector coordinates to common Roborock coordinates."""
+        for value in (x, y):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError("vector coordinates must be integers")
+            if not -(2**15) <= value < 2**15:
+                raise ValueError("vector coordinates are outside the Q10 map range")
+        return cls(
+            x=_ROBOROCK_COORDINATE_OFFSET_MM + x * _Q10_VECTOR_UNIT_MM,
+            y=_ROBOROCK_COORDINATE_OFFSET_MM + y * _Q10_VECTOR_UNIT_MM,
+        )
+
+    def to_vector(self) -> tuple[int, int]:
+        """Convert common Roborock coordinates to the Q10 vector grid."""
+        coordinates: list[int] = []
+        for value in (self.x, self.y):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError("coordinates must be integers")
+            relative_mm = value - _ROBOROCK_COORDINATE_OFFSET_MM
+            if relative_mm % _Q10_VECTOR_UNIT_MM:
+                raise ValueError("coordinates must align to the Q10 5 mm grid")
+            coordinate = relative_mm // _Q10_VECTOR_UNIT_MM
+            if not -(2**15) <= coordinate < 2**15:
+                raise ValueError("coordinates are outside the Q10 map range")
+            coordinates.append(coordinate)
+        return coordinates[0], coordinates[1]
+
 
 @dataclass
 class dpCleanRecord(RoborockBase):

--- a/roborock/data/b01_q10/b01_q10_containers.py
+++ b/roborock/data/b01_q10/b01_q10_containers.py
@@ -88,7 +88,9 @@ class Q10MapInfo(RoborockBase):
     """A saved map reported by ``dpMultiMap``.
 
     Q10 firmware represents the map identifier as a string on the wire. The
-    value is sent back unchanged in a subsequent ``{"op": "get"}`` request.
+    value is sent back unchanged in a subsequent ``{"op": "select"}`` detail
+    request. On Q10 firmware, ``select`` previews a saved map without applying
+    it as the active map.
     """
 
     id: str

--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -19,6 +19,7 @@ from roborock.data import (
 from roborock.devices.device import DeviceReadyCallback, RoborockDevice
 from roborock.diagnostics import Diagnostics, redact_device_data
 from roborock.exceptions import RoborockException
+from roborock.map.b01_q10_map_parser import B01Q10MapParserConfig
 from roborock.map.map_parser import MapParserConfig
 from roborock.mqtt.roborock_session import create_lazy_mqtt_session
 from roborock.mqtt.session import MqttSession, SessionUnauthorizedHook
@@ -262,7 +263,12 @@ async def create_device_manager(
                 if "ss" in model_part:
                     b01_q10_channel = create_b01_q10_channel(mqtt_channel)
                     channel = b01_q10_channel
-                    trait = b01.q10.create(channel)
+                    trait = b01.q10.create(
+                        channel,
+                        map_parser_config=(
+                            B01Q10MapParserConfig(map_scale=map_parser_config.map_scale) if map_parser_config else None
+                        ),
+                    )
                 elif "sc" in model_part:
                     # Q7 devices start with 'sc' in their model naming.
                     b01_q7_channel = create_b01_q7_channel(device, product, mqtt_channel)

--- a/roborock/devices/device_manager.py
+++ b/roborock/devices/device_manager.py
@@ -266,7 +266,12 @@ async def create_device_manager(
                     trait = b01.q10.create(
                         channel,
                         map_parser_config=(
-                            B01Q10MapParserConfig(map_scale=map_parser_config.map_scale) if map_parser_config else None
+                            B01Q10MapParserConfig(
+                                map_scale=map_parser_config.map_scale,
+                                drawables=map_parser_config.drawables,
+                            )
+                            if map_parser_config
+                            else None
                         ),
                     )
                 elif "sc" in model_part:

--- a/roborock/devices/traits/b01/q10/__init__.py
+++ b/roborock/devices/traits/b01/q10/__init__.py
@@ -8,7 +8,12 @@ from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
 from roborock.data.containers import RoborockBase
 from roborock.devices.rpc.b01_q10_channel import B01Q10Channel
 from roborock.devices.traits import Trait
-from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10MapPacketKind, Q10TracePacket
+from roborock.map.b01_q10_map_parser import (
+    B01Q10MapParserConfig,
+    Q10MapPacket,
+    Q10MapPacketKind,
+    Q10TracePacket,
+)
 from roborock.protocols.b01_q10_protocol import Q10DpsUpdate, Q10Message
 
 from .button_light import ButtonLightTrait
@@ -92,7 +97,12 @@ class Q10PropertiesApi(Trait):
     clean_history: CleanHistoryTrait
     """Trait for fetching the device clean-record history (``dpCleanRecord``)."""
 
-    def __init__(self, channel: B01Q10Channel) -> None:
+    def __init__(
+        self,
+        channel: B01Q10Channel,
+        *,
+        map_parser_config: B01Q10MapParserConfig | None = None,
+    ) -> None:
         """Initialize the B01Props API."""
         self._channel = channel
         self.command = CommandTrait(channel)
@@ -107,9 +117,16 @@ class Q10PropertiesApi(Trait):
         self.network_info = NetworkInfoTrait()
         self.consumable = ConsumableTrait()
         self._map_dps = MapDpsTrait()
-        self.maps = MapsTrait(self.command)
-        self.map = MapContentTrait(self._map_dps, self.maps, self.command)
-        self.clean_history = CleanHistoryTrait(self.command)
+        self.maps = MapsTrait(self.command, map_parser_config=map_parser_config)
+        self.map = MapContentTrait(
+            self._map_dps,
+            self.command,
+            map_parser_config=map_parser_config,
+        )
+        self.clean_history = CleanHistoryTrait(
+            self.command,
+            map_parser_config=map_parser_config,
+        )
         # Read-model traits updated from the device's DPS push stream.
         self._updatable_traits = [
             self.status,
@@ -183,6 +200,10 @@ class Q10PropertiesApi(Trait):
         return result
 
 
-def create(channel: B01Q10Channel) -> Q10PropertiesApi:
+def create(
+    channel: B01Q10Channel,
+    *,
+    map_parser_config: B01Q10MapParserConfig | None = None,
+) -> Q10PropertiesApi:
     """Create traits for B01 devices."""
-    return Q10PropertiesApi(channel)
+    return Q10PropertiesApi(channel, map_parser_config=map_parser_config)

--- a/roborock/devices/traits/b01/q10/__init__.py
+++ b/roborock/devices/traits/b01/q10/__init__.py
@@ -8,7 +8,7 @@ from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
 from roborock.data.containers import RoborockBase
 from roborock.devices.rpc.b01_q10_channel import B01Q10Channel
 from roborock.devices.traits import Trait
-from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10TracePacket
+from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10MapPacketKind, Q10TracePacket
 from roborock.protocols.b01_q10_protocol import Q10DpsUpdate, Q10Message
 
 from .button_light import ButtonLightTrait
@@ -157,7 +157,12 @@ class Q10PropertiesApi(Trait):
         Map-list DPS responses and other DPS updates feed the read-model traits.
         """
         if isinstance(message, Q10MapPacket):
-            self.map.update_from_map_packet(message)
+            if message.kind is Q10MapPacketKind.CURRENT:
+                self.map.update_from_map_packet(message)
+            elif message.kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL:
+                self.clean_history.update_from_map_packet(message)
+            elif message.kind is Q10MapPacketKind.SAVED_MAP_DETAIL:
+                self.maps.update_from_map_packet(message)
         elif isinstance(message, Q10TracePacket):
             self.map.update_from_trace_packet(message)
         elif isinstance(message, Q10DpsUpdate):

--- a/roborock/devices/traits/b01/q10/clean_history.py
+++ b/roborock/devices/traits/b01/q10/clean_history.py
@@ -22,6 +22,9 @@ from roborock.data.b01_q10.b01_q10_code_mappings import (
     YXStartMethod,
 )
 from roborock.data.b01_q10.b01_q10_containers import Q10CleanRecord
+from roborock.exceptions import RoborockException
+from roborock.map.b01_q10_map_parser import B01Q10MapParserConfig, Q10MapPacket, Q10MapPacketKind
+from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map
 
 from .command import CommandTrait
 from .common import UpdatableTrait
@@ -121,6 +124,10 @@ class CleanHistoryTrait(UpdatableTrait):
         self._converter = CleanRecordConverter()
         self.records: list[Q10CleanRecord] = []
         """Decoded clean records, most recent first."""
+        self.detail_packet: Q10MapPacket | None = None
+        """Most recently pushed ``03 01`` clean-record map detail."""
+        self.detail_image_content: bytes | None = None
+        """Rendered clean-record detail image, if decoding succeeded."""
 
     @property
     def last_record(self) -> Q10CleanRecord | None:
@@ -150,6 +157,23 @@ class CleanHistoryTrait(UpdatableTrait):
         if push is None:
             return
         self._apply(push)
+
+    def update_from_map_packet(self, packet: Q10MapPacket) -> None:
+        """Store and render a pushed clean-record detail map."""
+        if packet.kind is not Q10MapPacketKind.CLEAN_RECORD_DETAIL:
+            raise ValueError(f"Expected a Q10 clean-record detail packet, got {packet.kind.value}")
+        self.detail_packet = packet
+        try:
+            self.detail_image_content = render_q10_map(
+                packet,
+                None,
+                Q10MapOverlays(),
+                config=B01Q10MapParserConfig(),
+            )
+        except RoborockException as ex:
+            _LOGGER.debug("Failed to render Q10 clean-record detail: %s", ex)
+            self.detail_image_content = None
+        self._notify_update()
 
     def _apply(self, push: CleanRecordPush) -> None:
         """Merge or replace the records from ``push``, then sort newest-first and notify."""

--- a/roborock/devices/traits/b01/q10/clean_history.py
+++ b/roborock/devices/traits/b01/q10/clean_history.py
@@ -28,6 +28,7 @@ from roborock.map.b01_q10_map_parser import (
     Q10HistoricalTracePacket,
     Q10MapPacket,
     Q10MapPacketKind,
+    Q10Obstacle,
     Q10Point,
 )
 from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map
@@ -200,6 +201,11 @@ class CleanHistoryTrait(UpdatableTrait):
     def detail_path(self) -> list[Q10Point]:
         """Historical path points for the selected clean record."""
         return self.detail_trace.points if self.detail_trace else []
+
+    @property
+    def detail_obstacles(self) -> list[Q10Obstacle]:
+        """Obstacle markers embedded in the selected clean-record map."""
+        return list(self.detail_packet.obstacles) if self.detail_packet else []
 
     def update_from_dps(self, decoded_dps: dict[B01_Q10_DP, Any]) -> None:
         """Apply a ``dpCleanRecord`` push (a full list reply or a single notify)."""

--- a/roborock/devices/traits/b01/q10/clean_history.py
+++ b/roborock/devices/traits/b01/q10/clean_history.py
@@ -23,7 +23,13 @@ from roborock.data.b01_q10.b01_q10_code_mappings import (
 )
 from roborock.data.b01_q10.b01_q10_containers import Q10CleanRecord
 from roborock.exceptions import RoborockException
-from roborock.map.b01_q10_map_parser import B01Q10MapParserConfig, Q10MapPacket, Q10MapPacketKind
+from roborock.map.b01_q10_map_parser import (
+    B01Q10MapParserConfig,
+    Q10HistoricalTracePacket,
+    Q10MapPacket,
+    Q10MapPacketKind,
+    Q10Point,
+)
 from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map
 
 from .command import CommandTrait
@@ -118,16 +124,25 @@ class CleanHistoryTrait(UpdatableTrait):
     or a single ``op:"notify"`` record) rather than a flat data-point-to-field map.
     """
 
-    def __init__(self, command: CommandTrait) -> None:
+    def __init__(
+        self,
+        command: CommandTrait,
+        *,
+        map_parser_config: B01Q10MapParserConfig | None = None,
+    ) -> None:
         """Initialize the clean history trait."""
         UpdatableTrait.__init__(self, command, _LOGGER)
         self._converter = CleanRecordConverter()
+        self._map_parser_config = map_parser_config or B01Q10MapParserConfig()
         self.records: list[Q10CleanRecord] = []
         """Decoded clean records, most recent first."""
         self.detail_packet: Q10MapPacket | None = None
         """Most recently pushed ``03 01`` clean-record map detail."""
+        self.detail_record: Q10CleanRecord | None = None
+        """Record associated with :attr:`detail_packet`, when requested here."""
         self.detail_image_content: bytes | None = None
         """Rendered clean-record detail image, if decoding succeeded."""
+        self._pending_detail_record: Q10CleanRecord | None = None
 
     @property
     def last_record(self) -> Q10CleanRecord | None:
@@ -148,6 +163,44 @@ class CleanHistoryTrait(UpdatableTrait):
             params={str(B01_Q10_DP.CLEAN_RECORD.code): {"op": "list"}},
         )
 
+    async def refresh_detail(self, record: Q10CleanRecord) -> None:
+        """Request the saved map and path for one clean record.
+
+        The complete 12-field raw record is the firmware's detail identifier;
+        the shorter human-facing record ID is not accepted. Only one request
+        may be outstanding because ``03 01`` responses carry no correlation ID.
+        """
+        if self._command is None:
+            raise ValueError("Trait is read-only; no command channel was provided")
+        if not record.raw or not record.map_len:
+            raise RoborockException("The Q10 clean record has no saved map detail")
+        if self._pending_detail_record is not None:
+            raise RoborockException("A Q10 clean-record detail request is already pending")
+        self._pending_detail_record = record
+        try:
+            await self._command.send(
+                B01_Q10_DP.COMMON,
+                params={
+                    str(B01_Q10_DP.CLEAN_RECORD.code): {
+                        "op": "select",
+                        "id": record.raw,
+                    }
+                },
+            )
+        except Exception:
+            self._pending_detail_record = None
+            raise
+
+    @property
+    def detail_trace(self) -> Q10HistoricalTracePacket | None:
+        """Historical path embedded in the selected clean-record detail."""
+        return self.detail_packet.historical_trace if self.detail_packet else None
+
+    @property
+    def detail_path(self) -> list[Q10Point]:
+        """Historical path points for the selected clean record."""
+        return self.detail_trace.points if self.detail_trace else []
+
     def update_from_dps(self, decoded_dps: dict[B01_Q10_DP, Any]) -> None:
         """Apply a ``dpCleanRecord`` push (a full list reply or a single notify)."""
         envelope = decoded_dps.get(B01_Q10_DP.CLEAN_RECORD)
@@ -162,16 +215,18 @@ class CleanHistoryTrait(UpdatableTrait):
         """Store and render a pushed clean-record detail map."""
         if packet.kind is not Q10MapPacketKind.CLEAN_RECORD_DETAIL:
             raise ValueError(f"Expected a Q10 clean-record detail packet, got {packet.kind.value}")
+        self.detail_record = self._pending_detail_record
+        self._pending_detail_record = None
         self.detail_packet = packet
         try:
             self.detail_image_content = render_q10_map(
                 packet,
-                None,
+                packet.historical_trace,
                 Q10MapOverlays(),
-                config=B01Q10MapParserConfig(),
+                config=self._map_parser_config,
             )
-        except RoborockException as ex:
-            _LOGGER.debug("Failed to render Q10 clean-record detail: %s", ex)
+        except Exception:
+            _LOGGER.debug("Failed to render Q10 clean-record detail", exc_info=True)
             self.detail_image_content = None
         self._notify_update()
 

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -7,10 +7,10 @@ Map-related state arrives on three independent streams:
 * restricted zones, virtual walls and dock state arrive as ordinary DPS values.
 
 ``MapDpsTrait`` owns the low-level map-specific DPS read model.
-``MapContentTrait`` uses a stored ID from ``MapsTrait`` only when it requests
-content. It combines the latest map and trace packets with the map DPS state
-through the pure functions in :mod:`roborock.map.b01_q10_render`. Map-list
-updates do not refresh content.
+``MapContentTrait`` requests a current-map push through ``REQUEST_DPS`` and
+combines the latest map and trace packets with the map DPS state through the
+pure functions in :mod:`roborock.map.b01_q10_render`. Saved-map list/detail
+operations remain on ``MapsTrait``.
 """
 
 import logging
@@ -108,20 +108,13 @@ class MapContentTrait(TraitUpdateListener):
         self._map_dps.add_update_listener(self._map_dps_updated)
 
     async def refresh(self) -> None:
-        """Request content for the first map in the latest saved-map list."""
-        if (map_id := self._maps.current_map_id) is None:
-            raise RoborockException("Cannot request Q10 map content before the map list is available")
-        # Map lists and map content can change at different times. Reuse the
-        # stored ID so a content refresh does not also refresh the list.
-        await self._command.send(
-            B01_Q10_DP.COMMON,
-            {
-                str(B01_Q10_DP.MULTI_MAP.code): {
-                    "op": "get",
-                    "id": map_id,
-                }
-            },
-        )
+        """Request a safe asynchronous current-map/status push.
+
+        Some ss07 firmware treats ``dpMultiMap op:get`` as an active
+        cleaning/relocation command. ``REQUEST_DPS`` is the device's read-only
+        current-map request and does not depend on a saved-map ID.
+        """
+        await self._command.send(B01_Q10_DP.REQUEST_DPS, params={})
 
     @property
     def image_content(self) -> bytes | None:

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -24,6 +24,7 @@ from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import (
     B01Q10MapParserConfig,
     Q10MapPacket,
+    Q10MapPacketKind,
     Q10Point,
     Q10Room,
     Q10TracePacket,
@@ -149,6 +150,8 @@ class MapContentTrait(TraitUpdateListener):
 
     def update_from_map_packet(self, packet: Q10MapPacket) -> None:
         """Store a map-protocol update and render the latest sources."""
+        if packet.kind is not Q10MapPacketKind.CURRENT:
+            raise ValueError(f"Expected a current Q10 map packet, got {packet.kind.value}")
         self._map_packet = packet
         self._render()
         self._notify_update()

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -31,13 +31,21 @@ from roborock.map.b01_q10_map_parser import (
     Q10TracePacket,
 )
 from roborock.map.b01_q10_overlays import parse_virtual_wall_blob, parse_zone_blob
-from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map
+from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map, resolve_q10_current_room
 
 from .command import CommandTrait
 from .common import UpdatableTrait
 
 _LOGGER = logging.getLogger(__name__)
 _DOCKED_STATES = {YXDeviceState.CHARGING, YXDeviceState.EMPTYING_THE_BIN}
+_CURRENT_ROOM_STATES = {
+    YXDeviceState.CLEANING,
+    YXDeviceState.PAUSED,
+    YXDeviceState.SWEEPING,
+    YXDeviceState.MOPPING,
+    YXDeviceState.SWEEP_AND_MOP,
+    YXDeviceState.TRANSITIONING,
+}
 
 
 @dataclass
@@ -101,6 +109,7 @@ class MapContentTrait(TraitUpdateListener):
         self._command = command
         self._map_packet: Q10MapPacket | None = None
         self._trace_packet: Q10TracePacket | None = None
+        self._current_room_trace_fresh = False
         self._image_content: bytes | None = None
         self._map_revision = 0
         self._trace_revision = 0
@@ -155,6 +164,25 @@ class MapContentTrait(TraitUpdateListener):
         """Current heading for orienting a robot marker on a caller-rendered map."""
         return self._trace_packet.heading if self._trace_packet else None
 
+    @property
+    def current_room(self) -> Q10Room | None:
+        """Room currently occupied during an active or paused cleaning task.
+
+        No authoritative active-segment field has been identified or observed
+        on ss07 firmware. This value is inferred conservatively from the latest
+        live robot position and segmented occupancy grid, and is ``None``
+        outside cleaning states or whenever the position cannot be mapped
+        unambiguously.
+        """
+        if (
+            self._map_dps.status not in _CURRENT_ROOM_STATES
+            or self._map_packet is None
+            or self._trace_packet is None
+            or not self._current_room_trace_fresh
+        ):
+            return None
+        return resolve_q10_current_room(self._map_packet, self._trace_packet)
+
     def update_from_map_packet(self, packet: Q10MapPacket) -> None:
         """Store a map-protocol update and render the latest sources."""
         if packet.kind is not Q10MapPacketKind.CURRENT:
@@ -167,17 +195,26 @@ class MapContentTrait(TraitUpdateListener):
     def update_from_trace_packet(self, packet: Q10TracePacket) -> None:
         """Store a trace-protocol update and render the latest sources."""
         self._trace_packet = None if self._map_dps.robot_at_dock else packet
+        # A trace can precede the first status push during startup, but a trace
+        # received while an explicitly inactive state is known must never be
+        # reused as the position for a later cleaning session.
+        self._current_room_trace_fresh = self._trace_packet is not None and (
+            self._map_dps.status is None or self._map_dps.status in _CURRENT_ROOM_STATES
+        )
         self._trace_revision += 1
         self._render()
         self._notify_update()
 
     def _map_dps_updated(self) -> None:
         """Render after the low-level map DPS source changes."""
+        if self._map_dps.status is not None and self._map_dps.status not in _CURRENT_ROOM_STATES:
+            self._current_room_trace_fresh = False
         if self._map_dps.robot_at_dock and self._trace_packet is not None:
             # A completed cleaning trace is not the current robot position once
             # the device is docked. Clear the public live-path state even if the
             # firmware does not send its usual zero-point trace.
             self._trace_packet = None
+            self._current_room_trace_fresh = False
             self._trace_revision += 1
         if self._map_packet is None:
             return
@@ -203,12 +240,14 @@ class MapContentTrait(TraitUpdateListener):
     def as_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
         """Return the trait data as a dictionary, excluding large binary data."""
         exclude_set = exclude or set()
+        current_room = self.current_room
         data = {
             "rooms": [room.as_dict() for room in self.rooms],
             "obstacles": [obstacle.as_dict() for obstacle in self.obstacles],
             "path": [point.as_dict() for point in self.path],
             "robotPosition": self.robot_position.as_dict() if self.robot_position is not None else None,
             "robotHeading": self.robot_heading,
+            "currentRoom": current_room.as_dict() if current_room is not None else None,
         }
         for key in exclude_set:
             data.pop(key, None)

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -25,6 +25,7 @@ from roborock.map.b01_q10_map_parser import (
     B01Q10MapParserConfig,
     Q10MapPacket,
     Q10MapPacketKind,
+    Q10Obstacle,
     Q10Point,
     Q10Room,
     Q10TracePacket,
@@ -140,6 +141,11 @@ class MapContentTrait(TraitUpdateListener):
         return self._trace_packet.points if self._trace_packet else []
 
     @property
+    def obstacles(self) -> list[Q10Obstacle]:
+        """Position-only obstacle markers reported by the current map."""
+        return list(self._map_packet.obstacles) if self._map_packet else []
+
+    @property
     def robot_position(self) -> Q10Point | None:
         """Current position for live status and caller-rendered map overlays."""
         return self._trace_packet.robot_position if self._trace_packet else None
@@ -199,6 +205,7 @@ class MapContentTrait(TraitUpdateListener):
         exclude_set = exclude or set()
         data = {
             "rooms": [room.as_dict() for room in self.rooms],
+            "obstacles": [obstacle.as_dict() for obstacle in self.obstacles],
             "path": [point.as_dict() for point in self.path],
             "robotPosition": self.robot_position.as_dict() if self.robot_position is not None else None,
             "robotHeading": self.robot_heading,

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -34,7 +34,6 @@ from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map
 
 from .command import CommandTrait
 from .common import UpdatableTrait
-from .maps import MapsTrait
 
 _LOGGER = logging.getLogger(__name__)
 _DOCKED_STATES = {YXDeviceState.CHARGING, YXDeviceState.EMPTYING_THE_BIN}
@@ -84,15 +83,13 @@ class MapContentTrait(TraitUpdateListener):
     """High-level composed Q10 map view.
 
     The latest map and trace packets are combined with the injected
-    :class:`MapDpsTrait` whenever a source changes. The
-    :class:`MapsTrait` supplies a stored ID only when this trait requests
-    content.
+    :class:`MapDpsTrait` whenever a source changes. Current-map acquisition is
+    independent of the saved-map list.
     """
 
     def __init__(
         self,
         map_dps: MapDpsTrait,
-        maps: MapsTrait,
         command: CommandTrait,
         *,
         map_parser_config: B01Q10MapParserConfig | None = None,
@@ -100,11 +97,12 @@ class MapContentTrait(TraitUpdateListener):
         TraitUpdateListener.__init__(self, logger=_LOGGER)
         self._config = map_parser_config or B01Q10MapParserConfig()
         self._map_dps = map_dps
-        self._maps = maps
         self._command = command
         self._map_packet: Q10MapPacket | None = None
         self._trace_packet: Q10TracePacket | None = None
         self._image_content: bytes | None = None
+        self._map_revision = 0
+        self._trace_revision = 0
         self._map_dps.add_update_listener(self._map_dps_updated)
 
     async def refresh(self) -> None:
@@ -120,6 +118,16 @@ class MapContentTrait(TraitUpdateListener):
     def image_content(self) -> bytes | None:
         """The composed map PNG, if the latest map rendered successfully."""
         return self._image_content
+
+    @property
+    def map_revision(self) -> int:
+        """Monotonic revision incremented only by current-map packets."""
+        return self._map_revision
+
+    @property
+    def trace_revision(self) -> int:
+        """Monotonic revision incremented only by live-trace state changes."""
+        return self._trace_revision
 
     @property
     def rooms(self) -> list[Q10Room]:
@@ -146,17 +154,25 @@ class MapContentTrait(TraitUpdateListener):
         if packet.kind is not Q10MapPacketKind.CURRENT:
             raise ValueError(f"Expected a current Q10 map packet, got {packet.kind.value}")
         self._map_packet = packet
+        self._map_revision += 1
         self._render()
         self._notify_update()
 
     def update_from_trace_packet(self, packet: Q10TracePacket) -> None:
         """Store a trace-protocol update and render the latest sources."""
-        self._trace_packet = packet
+        self._trace_packet = None if self._map_dps.robot_at_dock else packet
+        self._trace_revision += 1
         self._render()
         self._notify_update()
 
     def _map_dps_updated(self) -> None:
         """Render after the low-level map DPS source changes."""
+        if self._map_dps.robot_at_dock and self._trace_packet is not None:
+            # A completed cleaning trace is not the current robot position once
+            # the device is docked. Clear the public live-path state even if the
+            # firmware does not send its usual zero-point trace.
+            self._trace_packet = None
+            self._trace_revision += 1
         if self._map_packet is None:
             return
         self._render()

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -14,11 +14,13 @@ operations remain on ``MapsTrait``.
 """
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
 from roborock.data import RoborockBase
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXDeviceState
+from roborock.data.b01_q10.b01_q10_containers import Q10RoborockPoint
 from roborock.devices.traits.common import DpsDataConverter, TraitUpdateListener
 from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import (
@@ -30,8 +32,20 @@ from roborock.map.b01_q10_map_parser import (
     Q10Room,
     Q10TracePacket,
 )
-from roborock.map.b01_q10_overlays import parse_virtual_wall_blob, parse_zone_blob
+from roborock.map.b01_q10_overlays import (
+    Q10RestrictedZone,
+    Q10RestrictionType,
+    Q10VirtualWall,
+    is_replaceable_zone_blob,
+    parse_virtual_wall_blob,
+    parse_zone_blob,
+)
 from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map, resolve_q10_current_room
+from roborock.protocols.b01_q10_protocol import (
+    encode_restricted_zones,
+    encode_room_name,
+    encode_virtual_walls,
+)
 
 from .command import CommandTrait
 from .common import UpdatableTrait
@@ -46,6 +60,10 @@ _CURRENT_ROOM_STATES = {
     YXDeviceState.SWEEP_AND_MOP,
     YXDeviceState.TRANSITIONING,
 }
+
+
+def _to_roborock_point(point: tuple[int, int]) -> Q10RoborockPoint:
+    return Q10RoborockPoint.from_vector(*point)
 
 
 @dataclass
@@ -153,6 +171,70 @@ class MapContentTrait(TraitUpdateListener):
     def obstacles(self) -> list[Q10Obstacle]:
         """Position-only obstacle markers reported by the current map."""
         return list(self._map_packet.obstacles) if self._map_packet else []
+
+    @property
+    def restricted_zones(self) -> tuple[Q10RestrictedZone, ...]:
+        """Restrictions reported by the device in common Roborock coordinates."""
+        restrictions: list[Q10RestrictedZone] = []
+        for zone in self._map_dps.overlays.zones:
+            if len(zone.vertices) != 4:
+                continue
+            vertices = (
+                _to_roborock_point(zone.vertices[0]),
+                _to_roborock_point(zone.vertices[1]),
+                _to_roborock_point(zone.vertices[2]),
+                _to_roborock_point(zone.vertices[3]),
+            )
+            restriction_type: int
+            try:
+                restriction_type = Q10RestrictionType(zone.type)
+            except ValueError:
+                restriction_type = zone.type
+            restrictions.append(Q10RestrictedZone(restriction_type, vertices))
+        return tuple(restrictions)
+
+    @property
+    def virtual_walls(self) -> tuple[Q10VirtualWall, ...]:
+        """Virtual walls reported by the device in common Roborock coordinates."""
+        walls: list[Q10VirtualWall] = []
+        for wall in self._map_dps.overlays.virtual_walls:
+            if len(wall.vertices) != 2:
+                continue
+            walls.append(
+                Q10VirtualWall(
+                    start=_to_roborock_point(wall.vertices[0]),
+                    end=_to_roborock_point(wall.vertices[1]),
+                )
+            )
+        return tuple(walls)
+
+    async def set_restricted_zones(self, zones: Sequence[Q10RestrictedZone]) -> None:
+        """Replace the complete restricted-zone collection."""
+        if not is_replaceable_zone_blob(self._map_dps.restricted_zone_up):
+            raise RoborockException("Cannot replace Q10 restrictions without a fully supported device snapshot")
+        payload = encode_restricted_zones(zones)
+        await self._command.send(
+            B01_Q10_DP.COMMON,
+            {str(B01_Q10_DP.RESTRICTED_ZONE.code): payload},
+        )
+
+    async def set_virtual_walls(self, walls: Sequence[Q10VirtualWall]) -> None:
+        """Replace the complete virtual-wall collection."""
+        payload = encode_virtual_walls(walls)
+        await self._command.send(
+            B01_Q10_DP.COMMON,
+            {str(B01_Q10_DP.VIRTUAL_WALL.code): payload},
+        )
+
+    async def set_room_name(self, room_id: int, name: str) -> None:
+        """Set the name of a room in the current map."""
+        if room_id not in {room.id for room in self.rooms}:
+            raise RoborockException(f"Unknown Q10 room ID: {room_id}")
+        payload = encode_room_name(room_id, name)
+        await self._command.send(
+            B01_Q10_DP.COMMON,
+            {str(B01_Q10_DP.RESET_ROOM_NAME.code): payload},
+        )
 
     @property
     def robot_position(self) -> Q10Point | None:

--- a/roborock/devices/traits/b01/q10/maps.py
+++ b/roborock/devices/traits/b01/q10/maps.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from roborock.data import RoborockBase
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
-from roborock.data.b01_q10.b01_q10_containers import dpMultiMap
+from roborock.data.b01_q10.b01_q10_containers import Q10MapInfo, dpMultiMap
 from roborock.devices.traits.common import DpsDataConverter
 from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import B01Q10MapParserConfig, Q10MapPacket, Q10MapPacketKind
@@ -31,6 +31,13 @@ class Maps(RoborockBase):
             return None
         return self.multi_map.current_map_id
 
+    @property
+    def map_list(self) -> list[Q10MapInfo]:
+        """Return a copy of the successfully reported saved-map list."""
+        if self.multi_map is None or self.multi_map.op != "list" or self.multi_map.result != 1:
+            return []
+        return list(self.multi_map.data)
+
 
 class MapsTrait(Maps, UpdatableTrait):
     """Request and store the Q10 saved-map list."""
@@ -38,15 +45,24 @@ class MapsTrait(Maps, UpdatableTrait):
     _CONVERTER = DpsDataConverter.from_dataclass(Maps)
     _command: CommandTrait
 
-    def __init__(self, command: CommandTrait) -> None:
+    def __init__(
+        self,
+        command: CommandTrait,
+        *,
+        map_parser_config: B01Q10MapParserConfig | None = None,
+    ) -> None:
         """Initialize the saved-map list trait."""
         Maps.__init__(self)
         UpdatableTrait.__init__(self, command, _LOGGER)
         self._command = command
+        self._map_parser_config = map_parser_config or B01Q10MapParserConfig()
         self.detail_packet: Q10MapPacket | None = None
         """Most recently pushed ``04 01`` saved-map detail."""
+        self.detail_map_id: str | None = None
+        """Saved-map ID associated with :attr:`detail_packet`."""
         self.detail_image_content: bytes | None = None
         """Rendered saved-map detail image, if decoding succeeded."""
+        self._pending_detail_map_id: str | None = None
 
     async def refresh(self) -> None:
         """Request a new saved-map list from the device."""
@@ -55,24 +71,35 @@ class MapsTrait(Maps, UpdatableTrait):
             {str(B01_Q10_DP.MULTI_MAP.code): {"op": "list"}},
         )
 
-    async def refresh_detail(self) -> None:
-        """Request detail for the current saved map.
+    async def refresh_detail(self, map_id: str | None = None) -> None:
+        """Request a read-only preview for one saved map.
 
         The device delivers the result asynchronously as a ``04 01`` map
         response, which :meth:`update_from_map_packet` stores separately from
         the live map.
         """
-        if (map_id := self.current_map_id) is None:
+        if map_id is None:
+            map_id = self.current_map_id
+        if map_id is None:
             raise RoborockException("Cannot request Q10 saved-map detail before the map list is available")
-        await self._command.send(
-            B01_Q10_DP.COMMON,
-            {
-                str(B01_Q10_DP.MULTI_MAP.code): {
-                    "op": "select",
-                    "id": map_id,
-                }
-            },
-        )
+        if map_id not in {map_info.id for map_info in self.map_list}:
+            raise RoborockException(f"Unknown Q10 saved-map ID: {map_id}")
+        if self._pending_detail_map_id is not None:
+            raise RoborockException("A Q10 saved-map detail request is already pending")
+        self._pending_detail_map_id = map_id
+        try:
+            await self._command.send(
+                B01_Q10_DP.COMMON,
+                {
+                    str(B01_Q10_DP.MULTI_MAP.code): {
+                        "op": "select",
+                        "id": map_id,
+                    }
+                },
+            )
+        except Exception:
+            self._pending_detail_map_id = None
+            raise
 
     def update_from_dps(self, decoded_dps: dict[B01_Q10_DP, Any]) -> None:
         """Store a successful saved-map list response."""
@@ -87,15 +114,25 @@ class MapsTrait(Maps, UpdatableTrait):
         """Store and render a pushed saved-map detail packet."""
         if packet.kind is not Q10MapPacketKind.SAVED_MAP_DETAIL:
             raise ValueError(f"Expected a Q10 saved-map detail packet, got {packet.kind.value}")
+        packet_map_id = str(packet.map_id)
+        if self._pending_detail_map_id is not None and packet_map_id != self._pending_detail_map_id:
+            _LOGGER.debug(
+                "Ignoring Q10 saved-map detail for map %s while waiting for %s",
+                packet_map_id,
+                self._pending_detail_map_id,
+            )
+            return
+        self.detail_map_id = packet_map_id
+        self._pending_detail_map_id = None
         self.detail_packet = packet
         try:
             self.detail_image_content = render_q10_map(
                 packet,
                 None,
                 Q10MapOverlays(),
-                config=B01Q10MapParserConfig(),
+                config=self._map_parser_config,
             )
-        except RoborockException as ex:
-            _LOGGER.debug("Failed to render Q10 saved-map detail: %s", ex)
+        except Exception:
+            _LOGGER.debug("Failed to render Q10 saved-map detail", exc_info=True)
             self.detail_image_content = None
         self._notify_update()

--- a/roborock/devices/traits/b01/q10/maps.py
+++ b/roborock/devices/traits/b01/q10/maps.py
@@ -81,6 +81,20 @@ class MapsTrait(Maps, UpdatableTrait):
             {str(B01_Q10_DP.MULTI_MAP.code): {"op": "list"}},
         )
 
+    async def set_current_map(self, map_id: str) -> None:
+        """Request a saved map without optimistically changing cached state."""
+        if not isinstance(map_id, str) or map_id not in {map_info.id for map_info in self.map_list}:
+            raise RoborockException(f"Unknown Q10 saved-map ID: {map_id}")
+        await self._command.send(
+            B01_Q10_DP.COMMON,
+            {
+                str(B01_Q10_DP.MULTI_MAP.code): {
+                    "op": "apply",
+                    "id": map_id,
+                }
+            },
+        )
+
     async def refresh_detail(self, map_id: str | None = None) -> None:
         """Request a read-only preview for one saved map.
 

--- a/roborock/devices/traits/b01/q10/maps.py
+++ b/roborock/devices/traits/b01/q10/maps.py
@@ -9,7 +9,12 @@ from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
 from roborock.data.b01_q10.b01_q10_containers import Q10MapInfo, dpMultiMap
 from roborock.devices.traits.common import DpsDataConverter
 from roborock.exceptions import RoborockException
-from roborock.map.b01_q10_map_parser import B01Q10MapParserConfig, Q10MapPacket, Q10MapPacketKind
+from roborock.map.b01_q10_map_parser import (
+    B01Q10MapParserConfig,
+    Q10MapPacket,
+    Q10MapPacketKind,
+    Q10Obstacle,
+)
 from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map
 
 from .command import CommandTrait
@@ -63,6 +68,11 @@ class MapsTrait(Maps, UpdatableTrait):
         self.detail_image_content: bytes | None = None
         """Rendered saved-map detail image, if decoding succeeded."""
         self._pending_detail_map_id: str | None = None
+
+    @property
+    def detail_obstacles(self) -> list[Q10Obstacle]:
+        """Obstacle markers embedded in the selected saved-map preview."""
+        return list(self.detail_packet.obstacles) if self.detail_packet else []
 
     async def refresh(self) -> None:
         """Request a new saved-map list from the device."""

--- a/roborock/devices/traits/b01/q10/maps.py
+++ b/roborock/devices/traits/b01/q10/maps.py
@@ -8,6 +8,9 @@ from roborock.data import RoborockBase
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
 from roborock.data.b01_q10.b01_q10_containers import dpMultiMap
 from roborock.devices.traits.common import DpsDataConverter
+from roborock.exceptions import RoborockException
+from roborock.map.b01_q10_map_parser import B01Q10MapParserConfig, Q10MapPacket, Q10MapPacketKind
+from roborock.map.b01_q10_render import Q10MapOverlays, render_q10_map
 
 from .command import CommandTrait
 from .common import UpdatableTrait
@@ -40,12 +43,35 @@ class MapsTrait(Maps, UpdatableTrait):
         Maps.__init__(self)
         UpdatableTrait.__init__(self, command, _LOGGER)
         self._command = command
+        self.detail_packet: Q10MapPacket | None = None
+        """Most recently pushed ``04 01`` saved-map detail."""
+        self.detail_image_content: bytes | None = None
+        """Rendered saved-map detail image, if decoding succeeded."""
 
     async def refresh(self) -> None:
         """Request a new saved-map list from the device."""
         await self._command.send(
             B01_Q10_DP.COMMON,
             {str(B01_Q10_DP.MULTI_MAP.code): {"op": "list"}},
+        )
+
+    async def refresh_detail(self) -> None:
+        """Request detail for the current saved map.
+
+        The device delivers the result asynchronously as a ``04 01`` map
+        response, which :meth:`update_from_map_packet` stores separately from
+        the live map.
+        """
+        if (map_id := self.current_map_id) is None:
+            raise RoborockException("Cannot request Q10 saved-map detail before the map list is available")
+        await self._command.send(
+            B01_Q10_DP.COMMON,
+            {
+                str(B01_Q10_DP.MULTI_MAP.code): {
+                    "op": "select",
+                    "id": map_id,
+                }
+            },
         )
 
     def update_from_dps(self, decoded_dps: dict[B01_Q10_DP, Any]) -> None:
@@ -56,3 +82,20 @@ class MapsTrait(Maps, UpdatableTrait):
         if not isinstance(response, dict) or response.get("op") != "list" or response.get("result") != 1:
             return
         super().update_from_dps(decoded_dps)
+
+    def update_from_map_packet(self, packet: Q10MapPacket) -> None:
+        """Store and render a pushed saved-map detail packet."""
+        if packet.kind is not Q10MapPacketKind.SAVED_MAP_DETAIL:
+            raise ValueError(f"Expected a Q10 saved-map detail packet, got {packet.kind.value}")
+        self.detail_packet = packet
+        try:
+            self.detail_image_content = render_q10_map(
+                packet,
+                None,
+                Q10MapOverlays(),
+                config=B01Q10MapParserConfig(),
+            )
+        except RoborockException as ex:
+            _LOGGER.debug("Failed to render Q10 saved-map detail: %s", ex)
+            self.detail_image_content = None
+        self._notify_update()

--- a/roborock/diagnostics.py
+++ b/roborock/diagnostics.py
@@ -108,6 +108,7 @@ REDACT_KEYS = {
     "wifiName",
     "lat",
     "long",
+    "rawName",
 }
 KEEP_KEYS = {
     # Product information not unique per user

--- a/roborock/map/b01_q10_map_parser.py
+++ b/roborock/map/b01_q10_map_parser.py
@@ -26,9 +26,11 @@ import statistics
 import struct
 from dataclasses import dataclass, field, replace
 from enum import Enum
+from typing import TypeVar
 
 from PIL import Image
 from vacuum_map_parser_base.config.color import ColorsPalette, SupportedColor
+from vacuum_map_parser_base.config.drawable import Drawable
 from vacuum_map_parser_base.config.image_config import ImageConfig
 from vacuum_map_parser_base.map_data import ImageData, MapData, Point
 
@@ -230,6 +232,10 @@ class Q10MapPacket:
     """Cleaning path embedded in a clean-record detail packet, if present."""
     trailing_bytes: bytes = b""
     """Bytes following all sections this parser can validate and decode."""
+    obstacles: list["Q10Obstacle"] = field(default_factory=list)
+    """Obstacle markers embedded after the carpet block (50 raw units/pixel)."""
+    skip_cleaning_points: list["Q10Point"] = field(default_factory=list)
+    """Firmware skip-clean markers embedded after obstacles (10 raw units/pixel)."""
 
     @property
     def layers(self) -> GridLayers:
@@ -245,6 +251,19 @@ class Q10Point(RoborockBase):
 
     x: int
     y: int
+
+
+@dataclass
+class Q10Obstacle(Q10Point):
+    """A Q10 map obstacle marker in its raw map-package coordinate frame.
+
+    The map package supplies positions only: there is no validated type,
+    confidence, or photo identifier on this model. Fifty raw units equal one
+    occupancy-grid pixel; placement is anchored by the map header origin.
+    """
+
+
+_PointType = TypeVar("_PointType", bound=Q10Point)
 
 
 @dataclass
@@ -328,13 +347,12 @@ _TRACE_SEQUENCE_OFFSET = 3
 _TRACE_POINT_COUNT_OFFSET = 8
 _TRACE_HEADING_OFFSET = 10
 
-_HISTORICAL_TRACE_HEADER_LENGTH = 14
-_HISTORICAL_TRACE_PREFIX_LENGTH = 1
+_HISTORICAL_TRACE_HEADER_LENGTH = 13
 _HISTORICAL_TRACE_VERSION = 1
-_HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET = 2
-_HISTORICAL_TRACE_POINT_COUNT_OFFSET = 6
-_HISTORICAL_TRACE_HEADING_OFFSET = 10
-_HISTORICAL_TRACE_RESERVED_OFFSET = 12
+_HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET = 1
+_HISTORICAL_TRACE_POINT_COUNT_OFFSET = 5
+_HISTORICAL_TRACE_HEADING_OFFSET = 9
+_HISTORICAL_TRACE_RESERVED_OFFSET = 11
 
 # Some cleans still prepend a single near-origin sentinel as the first real
 # point (e.g. ~(5, 76) / (-3, 0) when the path proper starts near (-1700, -800));
@@ -571,12 +589,21 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
     erase_zones = _parse_erase_zones(tail)
     carpet_mask, carpet_end = _parse_carpet_block(tail, width, height)
     trailing_offset = carpet_end if carpet_end is not None else _erase_section_end(tail)
-    if kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL and carpet_end is not None:
-        historical_trace, historical_trace_end = _parse_clean_record_trace(tail, carpet_end)
-        if historical_trace_end is not None:
-            trailing_offset = historical_trace_end
-    else:
-        historical_trace = None
+    obstacles: list[Q10Obstacle] = []
+    skip_cleaning_points: list[Q10Point] = []
+    historical_trace = None
+    if carpet_end is not None:
+        parsed_obstacles, obstacle_end = _parse_counted_points(tail, carpet_end, Q10Obstacle)
+        if obstacle_end is not None:
+            parsed_skip_points, skip_end = _parse_counted_points(tail, obstacle_end, Q10Point)
+            if skip_end is not None:
+                obstacles = parsed_obstacles
+                skip_cleaning_points = parsed_skip_points
+                trailing_offset = skip_end
+                if kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL:
+                    historical_trace, historical_trace_end = _parse_clean_record_trace(tail, skip_end)
+                    if historical_trace_end is not None:
+                        trailing_offset = historical_trace_end
     header_calibration = _parse_header_calibration(payload)
     return Q10MapPacket(
         map_id=map_id,
@@ -588,6 +615,8 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
         erase_zones=erase_zones,
         header_calibration=header_calibration,
         carpet_mask=carpet_mask,
+        obstacles=obstacles,
+        skip_cleaning_points=skip_cleaning_points,
         historical_trace=historical_trace,
         trailing_bytes=tail[trailing_offset:],
     )
@@ -710,6 +739,29 @@ def _parse_carpet_mask(tail: bytes, width: int, height: int) -> bytes | None:
     return _parse_carpet_block(tail, width, height)[0]
 
 
+def _parse_counted_points(
+    tail: bytes,
+    offset: int,
+    point_type: type[_PointType],
+) -> tuple[list[_PointType], int | None]:
+    """Decode one bounded ``u8 count`` + signed-BE ``(x, y)`` point table.
+
+    Obstacle and skip-clean sections use the same framing but different
+    coordinate scales. The caller owns those semantics; this helper only
+    validates and decodes the table atomically. A truncated table returns no
+    points and no end offset, preventing later sections from being misaligned.
+    """
+    if offset >= len(tail):
+        return [], None
+    count = tail[offset]
+    points_start = offset + 1
+    points_end = points_start + count * 4
+    if points_end > len(tail):
+        return [], None
+    coordinates = struct.iter_unpack(">hh", memoryview(tail)[points_start:points_end])
+    return ([point_type(x=x, y=y) for x, y in coordinates], points_end)
+
+
 def _parse_clean_record_trace(
     tail: bytes,
     offset: int,
@@ -718,20 +770,17 @@ def _parse_clean_record_trace(
 
     The header and declared point count were validated against a physical ss07
     clean-record response and its point bytes match captured prefixes of the
-    corresponding live trace exactly. One observed zero byte precedes the path;
-    its meaning is unknown, so a non-zero value makes the entire section opaque.
-    Any unsupported version, non-zero reserved word, or truncated point table is
-    likewise left completely opaque. Bytes after the declared points are
-    deliberately not consumed: the observed 12-byte suffix appears structured,
-    but there is not enough controlled evidence to name or decode it safely.
+    corresponding live trace exactly. The caller first consumes the obstacle
+    and skip-clean point tables; ``offset`` therefore starts at the one-byte
+    path version. Any unsupported version, non-zero reserved word, or truncated
+    point table is left completely opaque. Bytes after the declared points are
+    deliberately not consumed: the observed invariant 12-byte suffix appears
+    structured, but controlled captures disprove it as per-clean obstacles.
     """
-    if offset >= len(tail) or tail[offset] != 0:
-        return None, None
-    offset += _HISTORICAL_TRACE_PREFIX_LENGTH
     header_end = offset + _HISTORICAL_TRACE_HEADER_LENGTH
     if header_end > len(tail):
         return None, None
-    version = int.from_bytes(tail[offset : offset + 2], "big")
+    version = tail[offset]
     reserved = int.from_bytes(
         tail[offset + _HISTORICAL_TRACE_RESERVED_OFFSET : offset + _HISTORICAL_TRACE_RESERVED_OFFSET + 2],
         "big",
@@ -787,6 +836,8 @@ class B01Q10MapParserConfig:
 
     map_scale: int = 4
     """Scale factor for the rendered map image."""
+    drawables: list[Drawable] | None = None
+    """Enabled map overlays, or ``None`` for the Q10 defaults."""
 
 
 class B01Q10MapParser:

--- a/roborock/map/b01_q10_map_parser.py
+++ b/roborock/map/b01_q10_map_parser.py
@@ -133,6 +133,8 @@ class Q10Room(RoborockBase):
     @property
     def name(self) -> str:
         """User friendly room name (firmware ``rr_`` defaults are normalized)."""
+        if not self.raw_name.startswith("rr_"):
+            return self.raw_name
         return self.raw_name.removeprefix("rr_").replace("_", " ").strip().title()
 
 

--- a/roborock/map/b01_q10_map_parser.py
+++ b/roborock/map/b01_q10_map_parser.py
@@ -1,8 +1,9 @@
 """Parser for Roborock Q10 (B01/ss07) map packets.
 
-Q10 devices deliver map data as a protocol-301 ``MAP_RESPONSE`` message after a
-``dpMultiMap`` list/get request. Unlike the Q7 ``SCMap`` protobuf
-format, the Q10 uses a custom, unencrypted binary packet:
+Q10 devices deliver map data as protocol-301 ``MAP_RESPONSE`` pushes. Current
+maps follow a read-only status request, while saved-map and clean-record detail
+packets follow their respective ``select`` requests. Unlike the Q7 ``SCMap``
+protobuf format, the Q10 uses a custom, unencrypted binary packet:
 
 - ``01 01`` marker, then a ``u32be`` map id (bytes 2-5) and two consecutive
   ``u16be`` dimensions: grid width (bytes 7-8) and grid height (bytes 9-10).
@@ -22,7 +23,9 @@ https://github.com/v1b3c0d3x3r/roborock-qseries-map-bridge
 import io
 import math
 import statistics
+import struct
 from dataclasses import dataclass, field, replace
+from enum import Enum
 
 from PIL import Image
 from vacuum_map_parser_base.config.color import ColorsPalette, SupportedColor
@@ -68,6 +71,8 @@ def classify_q10_cell(value: int) -> str:
 
 MAP_PACKET_MARKER = b"\x01\x01"
 TRACE_PACKET_MARKER = b"\x02\x01"
+CLEAN_RECORD_MAP_PACKET_MARKER = b"\x03\x01"
+SAVED_MAP_PACKET_MARKER = b"\x04\x01"
 
 _MAP_ID_OFFSET = 2
 # Width and height are two consecutive u16be fields. An earlier revision read the
@@ -83,6 +88,7 @@ _LAYOUT_COMPRESSED_OFFSET = 29
 _ROOM_RECORD_LENGTH = 47
 _ROOM_NAME_LENGTH_OFFSET = 26
 _MAX_ROOMS = 32
+_MAX_GRID_CELLS = 16_000_000
 # Sanity bound for the erase-zone vector section's vertices-per-polygon field.
 _MAX_ERASE_ZONE_VERTICES = 16
 
@@ -194,9 +200,17 @@ class Q10HeaderCalibration:
         )
 
 
+class Q10MapPacketKind(Enum):
+    """Semantic kind identified by a Q10 map packet's two-byte marker."""
+
+    CURRENT = "current"
+    CLEAN_RECORD_DETAIL = "clean_record_detail"
+    SAVED_MAP_DETAIL = "saved_map_detail"
+
+
 @dataclass
 class Q10MapPacket:
-    """Decoded contents of a Q10 ``01 01`` map packet."""
+    """Decoded contents of a Q10 current or archived map packet."""
 
     map_id: int
     width: int
@@ -211,6 +225,11 @@ class Q10MapPacket:
     """Carpet mask decoded from the packet tail: a full ``width*height`` grid in
     the same (top-down) pixel space as :attr:`grid`, where a non-zero cell is
     carpet (the value is the carpet kind). ``None`` if the packet carried none."""
+    kind: Q10MapPacketKind = Q10MapPacketKind.CURRENT
+    historical_trace: "Q10HistoricalTracePacket | None" = None
+    """Cleaning path embedded in a clean-record detail packet, if present."""
+    trailing_bytes: bytes = b""
+    """Bytes following all sections this parser can validate and decode."""
 
     @property
     def layers(self) -> GridLayers:
@@ -266,6 +285,27 @@ class Q10TracePacket:
         return self.points[-1] if self.points else None
 
 
+@dataclass
+class Q10HistoricalTracePacket:
+    """Cleaning path embedded in a Q10 ``03 01`` clean-record detail packet.
+
+    This is a different wire layout from the live ``02 01`` trace. Its header
+    carries a 16-bit format version, a 32-bit opaque value, a 32-bit
+    point count, a signed heading, and a zero reserved word. Points use the same
+    signed big-endian ``(x, y)`` coordinate pairs as the live trace.
+    """
+
+    points: list[Q10Point] = field(default_factory=list)
+    version: int = 0
+    opaque_value: int = 0
+    heading: int = 0
+
+    @property
+    def robot_position(self) -> Q10Point | None:
+        """The final recorded position, if the historical path is non-empty."""
+        return self.points[-1] if self.points else None
+
+
 # Trace packet (``02 01``): a 14-byte header followed by big-endian int16 (x, y)
 # point pairs forming the accumulated session path. Header layout confirmed
 # against live ss07 captures and cross-checked by @andrewlyeats:
@@ -275,17 +315,26 @@ class Q10TracePacket:
 # - bytes 10-11: the 0201 SLAM heading (s16be degrees; 0 = +x, +90 = +y,
 #   +-180 = -x, -90 = -y) -- the robot's current orientation.
 # - bytes 12-13: a constant (0x0000).
-# - byte 14 onward: the path points.
+# - byte 14 onward: exactly ``point_count`` path points.
 # An earlier revision used a 10-byte header, which folded the heading word into
 # a phantom leading point ``(heading, 0)`` -- that is the "stray point" the
 # heuristic below was papering over, and why the count read "one high". The
-# parser reads all 4-byte pairs in the body rather than trusting the count
-# field, so a truncated tail can't desync it.
+# parser requires the declared point count to match the complete body, so a
+# truncated or extended tail cannot be silently interpreted as path data.
 # NOTE: the format documented by roborock-qseries-map-bridge (18-byte header)
 # did not match this firmware -- this 14-byte layout is what the device sent.
 _TRACE_HEADER_LENGTH = 14
 _TRACE_SEQUENCE_OFFSET = 3
+_TRACE_POINT_COUNT_OFFSET = 8
 _TRACE_HEADING_OFFSET = 10
+
+_HISTORICAL_TRACE_HEADER_LENGTH = 14
+_HISTORICAL_TRACE_PREFIX_LENGTH = 1
+_HISTORICAL_TRACE_VERSION = 1
+_HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET = 2
+_HISTORICAL_TRACE_POINT_COUNT_OFFSET = 6
+_HISTORICAL_TRACE_HEADING_OFFSET = 10
+_HISTORICAL_TRACE_RESERVED_OFFSET = 12
 
 # Some cleans still prepend a single near-origin sentinel as the first real
 # point (e.g. ~(5, 76) / (-3, 0) when the path proper starts near (-1700, -800));
@@ -304,6 +353,25 @@ def is_map_packet(payload: bytes) -> bool:
     return payload[:2] == MAP_PACKET_MARKER
 
 
+def is_clean_record_map_packet(payload: bytes) -> bool:
+    """Return True for a Q10 clean-record detail (``03 01``) packet."""
+    return payload[:2] == CLEAN_RECORD_MAP_PACKET_MARKER
+
+
+def is_saved_map_packet(payload: bytes) -> bool:
+    """Return True for a Q10 saved-map detail (``04 01``) packet."""
+    return payload[:2] == SAVED_MAP_PACKET_MARKER
+
+
+def map_packet_kind(payload: bytes) -> Q10MapPacketKind | None:
+    """Classify a Q10 map marker without parsing the packet body."""
+    return {
+        MAP_PACKET_MARKER: Q10MapPacketKind.CURRENT,
+        CLEAN_RECORD_MAP_PACKET_MARKER: Q10MapPacketKind.CLEAN_RECORD_DETAIL,
+        SAVED_MAP_PACKET_MARKER: Q10MapPacketKind.SAVED_MAP_DETAIL,
+    }.get(payload[:2])
+
+
 def is_trace_packet(payload: bytes) -> bool:
     """Return True if the payload is a Q10 live trace (``02 01``) packet."""
     return payload[:2] == TRACE_PACKET_MARKER
@@ -318,6 +386,9 @@ def parse_trace_packet(payload: bytes) -> Q10TracePacket:
     body = payload[_TRACE_HEADER_LENGTH:]
     if len(body) % 4:
         raise RoborockException("Q10 trace points are not 4-byte (x, y) pairs")
+    declared_point_count = int.from_bytes(payload[_TRACE_POINT_COUNT_OFFSET : _TRACE_POINT_COUNT_OFFSET + 2], "big")
+    if declared_point_count != len(body) // 4:
+        raise RoborockException("Q10 trace point count does not match its payload")
 
     heading = int.from_bytes(payload[_TRACE_HEADING_OFFSET : _TRACE_HEADING_OFFSET + 2], "big", signed=True)
     points = [
@@ -348,11 +419,13 @@ def _drop_stray_leading_point(points: list[Q10Point]) -> list[Q10Point]:
     return points
 
 
-def lz4_block_decompress(data: bytes) -> bytes:
+def lz4_block_decompress(data: bytes, max_output_size: int | None = None) -> bytes:
     """Decompress a raw LZ4 *block* (no frame header).
 
     The Q10 map grid is stored as a single LZ4 block. This implements the
-    standard LZ4 block format so we don't add a native dependency.
+    standard LZ4 block format so we don't add a native dependency. When
+    ``max_output_size`` is supplied, expansion beyond it is rejected before
+    allocating the excess output.
     """
     index = 0
     output = bytearray()
@@ -380,6 +453,8 @@ def lz4_block_decompress(data: bytes) -> bytes:
         end = index + literal_length
         if end > len(data):
             raise RoborockException("Truncated LZ4 block while reading literals")
+        if max_output_size is not None and len(output) + literal_length > max_output_size:
+            raise RoborockException("LZ4 block exceeds maximum output size")
         output.extend(data[index:end])
         index = end
 
@@ -394,6 +469,8 @@ def lz4_block_decompress(data: bytes) -> bytes:
             raise RoborockException("Invalid LZ4 back-reference offset")
 
         match_length = read_length(token & 0x0F) + 4
+        if max_output_size is not None and len(output) + match_length > max_output_size:
+            raise RoborockException("LZ4 block exceeds maximum output size")
         for _ in range(match_length):
             output.append(output[-offset])
 
@@ -458,8 +535,9 @@ def _parse_rooms(room_data: bytes, grid: bytes) -> list[Q10Room]:
 
 
 def parse_map_packet(payload: bytes) -> Q10MapPacket:
-    """Parse a Q10 ``01 01`` map packet into grid + room metadata."""
-    if len(payload) < _LAYOUT_COMPRESSED_OFFSET or not is_map_packet(payload):
+    """Parse a Q10 current or archived map into typed source data."""
+    kind = map_packet_kind(payload)
+    if len(payload) < _LAYOUT_COMPRESSED_OFFSET or kind is None:
         raise RoborockException("Payload is not a Q10 map packet")
 
     map_id = int.from_bytes(payload[_MAP_ID_OFFSET : _MAP_ID_OFFSET + 4], "big")
@@ -467,6 +545,8 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
     height = int.from_bytes(payload[_HEIGHT_OFFSET : _HEIGHT_OFFSET + 2], "big")
     if width <= 0:
         raise RoborockException("Q10 map packet has invalid width")
+    if height > 0 and width * height > _MAX_GRID_CELLS:
+        raise RoborockException("Q10 map packet dimensions exceed the supported grid size")
 
     compressed_length = int.from_bytes(
         payload[_COMPRESSED_LAYOUT_LENGTH_OFFSET : _COMPRESSED_LAYOUT_LENGTH_OFFSET + 2], "big"
@@ -475,7 +555,10 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
     if compressed_length <= 0 or layout_end > len(payload):
         raise RoborockException("Q10 map packet has invalid layout block length")
 
-    decoded = lz4_block_decompress(payload[_LAYOUT_COMPRESSED_OFFSET:layout_end])
+    decoded = lz4_block_decompress(
+        payload[_LAYOUT_COMPRESSED_OFFSET:layout_end],
+        max_output_size=_MAX_GRID_CELLS + 2 + _MAX_ROOMS * _ROOM_RECORD_LENGTH,
+    )
     # Prefer the header height; fall back to inference if it doesn't line up
     # (e.g. older captures/fixtures that don't populate the height field).
     split = _split_with_dims(decoded, width, height) if height > 0 else None
@@ -486,17 +569,27 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
     rooms = _parse_rooms(room_data, grid)
     tail = payload[layout_end:]
     erase_zones = _parse_erase_zones(tail)
-    carpet_mask = _parse_carpet_mask(tail, width, height)
+    carpet_mask, carpet_end = _parse_carpet_block(tail, width, height)
+    trailing_offset = carpet_end if carpet_end is not None else _erase_section_end(tail)
+    if kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL and carpet_end is not None:
+        historical_trace, historical_trace_end = _parse_clean_record_trace(tail, carpet_end)
+        if historical_trace_end is not None:
+            trailing_offset = historical_trace_end
+    else:
+        historical_trace = None
     header_calibration = _parse_header_calibration(payload)
     return Q10MapPacket(
         map_id=map_id,
         width=width,
         height=height,
         grid=grid,
+        kind=kind,
         rooms=rooms,
         erase_zones=erase_zones,
         header_calibration=header_calibration,
         carpet_mask=carpet_mask,
+        historical_trace=historical_trace,
+        trailing_bytes=tail[trailing_offset:],
     )
 
 
@@ -569,7 +662,18 @@ def _carpet_offset(tail: bytes) -> int:
     return 2 + count * vertices_per * 4
 
 
-def _parse_carpet_mask(tail: bytes, width: int, height: int) -> bytes | None:
+def _erase_section_end(tail: bytes) -> int:
+    """Return the end of a complete, structurally valid erase section."""
+    if len(tail) < 2:
+        return 0
+    count, vertices_per = tail[0], tail[1]
+    if count and not 1 <= vertices_per <= _MAX_ERASE_ZONE_VERTICES:
+        return 0
+    end = _carpet_offset(tail)
+    return end if end <= len(tail) else 0
+
+
+def _parse_carpet_block(tail: bytes, width: int, height: int) -> tuple[bytes | None, int | None]:
     """Decode the carpet mask that follows the erase section in the packet tail.
 
     Framing matches the main grid block: ``[u32 uncompressed_len]``
@@ -578,23 +682,88 @@ def _parse_carpet_mask(tail: bytes, width: int, height: int) -> bytes | None:
     non-zero cell is carpet (the value is the carpet kind). Confirmed byte-exact
     on live ss07 captures (R1 / RDC), where ``uncompressed_len == width*height``.
 
-    Returns the decompressed mask, or ``None`` if the section is absent or does
-    not line up (the ``uncompressed_len == width*height`` invariant is used as the
-    guard so a mis-located section yields no carpet rather than garbage).
+    Returns the decompressed mask and its end offset. Both are ``None`` if the
+    section is absent or does not line up. The end offset is used to anchor
+    optional later sections without scanning arbitrary trailing bytes.
     """
-    offset = _carpet_offset(tail)
+    offset = _erase_section_end(tail)
+    if offset == 0:
+        return None, None
     if offset + 6 > len(tail):
-        return None
+        return None, None
     uncompressed_len = int.from_bytes(tail[offset : offset + 4], "big")
     compressed_len = int.from_bytes(tail[offset + 4 : offset + 6], "big")
     block_end = offset + 6 + compressed_len
     if uncompressed_len != width * height or compressed_len <= 0 or block_end > len(tail):
-        return None
+        return None, None
     try:
-        mask = lz4_block_decompress(tail[offset + 6 : block_end])
+        mask = lz4_block_decompress(tail[offset + 6 : block_end], max_output_size=width * height)
     except RoborockException:
-        return None
-    return mask if len(mask) == width * height else None
+        return None, None
+    if len(mask) != width * height:
+        return None, None
+    return mask, block_end
+
+
+def _parse_carpet_mask(tail: bytes, width: int, height: int) -> bytes | None:
+    """Decode only the optional carpet mask (compatibility helper)."""
+    return _parse_carpet_block(tail, width, height)[0]
+
+
+def _parse_clean_record_trace(
+    tail: bytes,
+    offset: int,
+) -> tuple[Q10HistoricalTracePacket | None, int | None]:
+    """Decode the bounded historical path following a ``03 01`` carpet block.
+
+    The header and declared point count were validated against a physical ss07
+    clean-record response and its point bytes match captured prefixes of the
+    corresponding live trace exactly. One observed zero byte precedes the path;
+    its meaning is unknown, so a non-zero value makes the entire section opaque.
+    Any unsupported version, non-zero reserved word, or truncated point table is
+    likewise left completely opaque. Bytes after the declared points are
+    deliberately not consumed: the observed 12-byte suffix appears structured,
+    but there is not enough controlled evidence to name or decode it safely.
+    """
+    if offset >= len(tail) or tail[offset] != 0:
+        return None, None
+    offset += _HISTORICAL_TRACE_PREFIX_LENGTH
+    header_end = offset + _HISTORICAL_TRACE_HEADER_LENGTH
+    if header_end > len(tail):
+        return None, None
+    version = int.from_bytes(tail[offset : offset + 2], "big")
+    reserved = int.from_bytes(
+        tail[offset + _HISTORICAL_TRACE_RESERVED_OFFSET : offset + _HISTORICAL_TRACE_RESERVED_OFFSET + 2],
+        "big",
+    )
+    if version != _HISTORICAL_TRACE_VERSION or reserved != 0:
+        return None, None
+    point_count = int.from_bytes(
+        tail[offset + _HISTORICAL_TRACE_POINT_COUNT_OFFSET : offset + _HISTORICAL_TRACE_POINT_COUNT_OFFSET + 4],
+        "big",
+    )
+    points_end = header_end + point_count * 4
+    if points_end > len(tail):
+        return None, None
+    coordinates = struct.iter_unpack(">hh", memoryview(tail)[header_end:points_end])
+    return (
+        Q10HistoricalTracePacket(
+            points=[Q10Point(x=x, y=y) for x, y in coordinates],
+            version=version,
+            opaque_value=int.from_bytes(
+                tail[
+                    offset + _HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET : offset + _HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET + 4
+                ],
+                "big",
+            ),
+            heading=int.from_bytes(
+                tail[offset + _HISTORICAL_TRACE_HEADING_OFFSET : offset + _HISTORICAL_TRACE_HEADING_OFFSET + 2],
+                "big",
+                signed=True,
+            ),
+        ),
+        points_end,
+    )
 
 
 def erased_packet(packet: "Q10MapPacket", cells: set[int]) -> "Q10MapPacket":

--- a/roborock/map/b01_q10_overlays.py
+++ b/roborock/map/b01_q10_overlays.py
@@ -30,6 +30,9 @@ layer.
 import base64
 import binascii
 from dataclasses import dataclass, field
+from enum import IntEnum
+
+from roborock.data.b01_q10.b01_q10_containers import Q10RoborockPoint
 
 _DEFAULT_RECORD_SIZE = 38  # 2-byte record header + up to 9 (x, y) int16 pairs
 
@@ -40,6 +43,30 @@ class Q10Zone:
 
     type: int
     vertices: list[tuple[int, int]] = field(default_factory=list)
+
+
+class Q10RestrictionType(IntEnum):
+    """Restriction types supported by the Q10 map editor."""
+
+    NO_GO = 0
+    NO_MOP = 2
+    THRESHOLD = 3
+
+
+@dataclass(frozen=True)
+class Q10RestrictedZone:
+    """A four-point restriction; unknown wire types remain raw integers."""
+
+    type: int
+    vertices: tuple[Q10RoborockPoint, Q10RoborockPoint, Q10RoborockPoint, Q10RoborockPoint]
+
+
+@dataclass(frozen=True)
+class Q10VirtualWall:
+    """A virtual wall in common Roborock coordinates."""
+
+    start: Q10RoborockPoint
+    end: Q10RoborockPoint
 
 
 def _decode_blob(data: str | None) -> bytes:
@@ -55,8 +82,8 @@ def parse_zone_blob(data: str | None) -> list[Q10Zone]:
     """Decode a Q10 zone/wall overlay blob into a list of :class:`Q10Zone`.
 
     Accepts the base64 string straight from the data point. Returns ``[]`` for
-    empty/absent/unparsable blobs (the device sends a single ``0x00`` byte when
-    there are none).
+    empty/absent/unparsable blobs. Empty DP 55 reports contain version ``1``
+    and count ``0``; some firmware appends one padding byte.
     """
     raw = _decode_blob(data)
     if len(raw) < 2:
@@ -89,6 +116,21 @@ def parse_zone_blob(data: str | None) -> list[Q10Zone]:
         ]
         zones.append(Q10Zone(type=zone_type, vertices=vertices))
     return zones
+
+
+def is_replaceable_zone_blob(data: str | None) -> bool:
+    """Return whether every record can be preserved by the zone writer."""
+    raw = _decode_blob(data)
+    if len(raw) < 2:
+        return False
+    count = raw[1]
+    if count == 0:
+        return True
+    body = raw[2:]
+    if len(body) % count:
+        return False
+    record_size = len(body) // count
+    return record_size >= 18 and all(body[index * record_size + 1] == 4 for index in range(count))
 
 
 _WALL_RECORD_SIZE = 8  # two (x, y) int16-BE endpoints
@@ -156,7 +198,7 @@ def parse_virtual_wall_blob(data: str | None) -> list[Q10Zone]:
 # Corrected from an earlier reading that treated type 3 as no-mop -- 3 is the
 # door-threshold rectangle; the no-mop area reads back as type 2. Reported and
 # verified by @andrewlyeats (ss07 read-backs + the ioBroker Q10 parser).
-ZONE_TYPE_NO_GO = 0
+ZONE_TYPE_NO_GO = Q10RestrictionType.NO_GO.value
 ZONE_TYPE_VIRTUAL_WALL = 1
-ZONE_TYPE_NO_MOP = 2
-ZONE_TYPE_THRESHOLD = 3
+ZONE_TYPE_NO_MOP = Q10RestrictionType.NO_MOP.value
+ZONE_TYPE_THRESHOLD = Q10RestrictionType.THRESHOLD.value

--- a/roborock/map/b01_q10_render.py
+++ b/roborock/map/b01_q10_render.py
@@ -34,6 +34,7 @@ from .b01_q10_map_parser import (
     B01Q10MapParser,
     B01Q10MapParserConfig,
     Q10EraseZone,
+    Q10HistoricalTracePacket,
     Q10MapPacket,
     Q10TracePacket,
     erased_packet,
@@ -62,7 +63,6 @@ _MIN_CALIBRATION_POINTS = 20
 # a much shorter path suffices to confirm it (early in a clean, not just a dense
 # one). See :func:`solve_calibration_with_origin`.
 _MIN_HEADER_CALIBRATION_POINTS = 4
-
 _Q10_DRAWABLE_TYPES = {
     Drawable.CHARGER,
     Drawable.NO_GO_AREAS,
@@ -84,7 +84,7 @@ class Q10MapOverlays:
 
 def render_q10_map(
     packet: Q10MapPacket,
-    trace: Q10TracePacket | None,
+    trace: Q10TracePacket | Q10HistoricalTracePacket | None,
     overlays: Q10MapOverlays,
     *,
     config: B01Q10MapParserConfig,
@@ -133,7 +133,7 @@ def render_q10_map(
 
 def solve_q10_calibration(
     packet: Q10MapPacket,
-    trace: Q10TracePacket | None,
+    trace: Q10TracePacket | Q10HistoricalTracePacket | None,
 ) -> GridCalibration | None:
     """Derive world-to-pixel calibration from a map and its current trace.
 
@@ -232,7 +232,7 @@ def _erased_cells(
 def _place_trace(
     map_data: MapData,
     calibration: GridCalibration,
-    trace: Q10TracePacket,
+    trace: Q10TracePacket | Q10HistoricalTracePacket,
     *,
     charger_heading: int | None = None,
 ) -> None:

--- a/roborock/map/b01_q10_render.py
+++ b/roborock/map/b01_q10_render.py
@@ -185,8 +185,10 @@ def _vector_calibration(
     trace_calibration: GridCalibration | None,
 ) -> GridCalibration | None:
     """Derive the 5 mm erase/restriction-vector transform."""
-    y_sign = trace_calibration.y_sign if trace_calibration is not None else 1
-    if calibration := _calibration_from_header_metadata(packet, y_sign=y_sign):
+    # Header vectors share the map packet's fixed top-down coordinate frame.
+    # A trace fit may choose either Y orientation, but that must not move saved
+    # erase/restriction geometry when a cleaning trace appears or disappears.
+    if calibration := _calibration_from_header_metadata(packet):
         return calibration
     if trace_calibration is None:
         return None

--- a/roborock/map/b01_q10_render.py
+++ b/roborock/map/b01_q10_render.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 from vacuum_map_parser_base.config.drawable import Drawable
 from vacuum_map_parser_base.config.size import Size, Sizes
-from vacuum_map_parser_base.map_data import Area, MapData, Path, Point, Wall
+from vacuum_map_parser_base.map_data import Area, MapData, Obstacle, ObstacleDetails, Path, Point, Wall
 
 from roborock.exceptions import RoborockException
 
@@ -67,6 +67,7 @@ _Q10_DRAWABLE_TYPES = {
     Drawable.CHARGER,
     Drawable.NO_GO_AREAS,
     Drawable.NO_MOPPING_AREAS,
+    Drawable.OBSTACLES,
     Drawable.PATH,
     Drawable.VACUUM_POSITION,
     Drawable.VIRTUAL_WALLS,
@@ -114,7 +115,7 @@ def render_q10_map(
         raise RoborockException("Failed to render Q10 map image")
     map_data = parsed.map_data
 
-    has_drawables = False
+    has_drawables = _place_obstacles(map_data, packet)
     if trace_calibration is not None and trace is not None:
         charger_heading = packet.header_calibration.charger_phi if packet.header_calibration is not None else None
         _place_trace(map_data, trace_calibration, trace, charger_heading=charger_heading)
@@ -129,6 +130,30 @@ def render_q10_map(
         return _draw_map_content(map_data, config=config)
 
     return parsed.image_content
+
+
+def _obstacle_calibration(packet: Q10MapPacket) -> GridCalibration | None:
+    """Build the obstacle-table transform from the map header.
+
+    Q10 obstacle positions use 50 raw units per occupancy-grid pixel, unlike
+    the 5 mm restriction vectors and 2.5 mm cleaning traces.
+    """
+    header = packet.header_calibration
+    if header is None or (origin := header.origin_pixels()) is None:
+        return None
+    return GridCalibration(resolution=50.0, origin_x=origin[0], origin_y=origin[1], y_sign=1)
+
+
+def _place_obstacles(map_data: MapData, packet: Q10MapPacket) -> bool:
+    """Project position-only Q10 obstacle markers into shared ``MapData``."""
+    calibration = _obstacle_calibration(packet)
+    if calibration is None or not packet.obstacles:
+        return False
+    map_data.obstacles = [
+        Obstacle(*calibration.world_to_pixel(obstacle.x, obstacle.y), ObstacleDetails())
+        for obstacle in packet.obstacles
+    ]
+    return True
 
 
 def solve_q10_calibration(
@@ -326,10 +351,10 @@ def _draw_map_content(
     """Draw Q10 content with the shared V1 image generator."""
     if map_data.image is None:
         raise RoborockException("Failed to render Q10 map image")
-    generator = _create_image_generator(
-        MapParserConfig(map_scale=config.map_scale),
-        drawables=_Q10_DRAWABLES,
+    drawables = (
+        _Q10_DRAWABLES if config.drawables is None else [d for d in config.drawables if d in _Q10_DRAWABLE_TYPES]
     )
+    generator = _create_image_generator(MapParserConfig(map_scale=config.map_scale), drawables=drawables)
     generator.draw_map(map_data)
     buffer = io.BytesIO()
     map_data.image.data.save(buffer, format="PNG")

--- a/roborock/map/b01_q10_render.py
+++ b/roborock/map/b01_q10_render.py
@@ -16,7 +16,7 @@ drawing) and the calibration policy live here, next to the rest of the map code.
 import io
 import math
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from vacuum_map_parser_base.config.drawable import Drawable
 from vacuum_map_parser_base.config.size import Size, Sizes
@@ -28,7 +28,6 @@ from .b01_grid_layers import (
     GridCalibration,
     GridLayers,
     solve_calibration,
-    solve_calibration_with_origin,
 )
 from .b01_q10_map_parser import (
     B01Q10MapParser,
@@ -36,13 +35,16 @@ from .b01_q10_map_parser import (
     Q10EraseZone,
     Q10HistoricalTracePacket,
     Q10MapPacket,
+    Q10Point,
+    Q10Room,
     Q10TracePacket,
     erased_packet,
 )
 from .b01_q10_overlays import ZONE_TYPE_NO_GO, ZONE_TYPE_NO_MOP, Q10Zone
 from .map_parser import DEFAULT_DRAWABLES, MapParserConfig, _create_image_generator
 
-# Path-units-per-pixel candidates for calibration. A dense ss07 path lands a
+# Path-units-per-pixel candidates for packets without usable header metadata.
+# A dense ss07 path lands a
 # best fit of 20.0 around the header origin -- ground-truthed June 2026 on the
 # R1: a corridor drive registered at 20 (matching the format author's
 # independent "20 path-units/px"), and the dock->corridor span lined up with the
@@ -56,13 +58,13 @@ _Q10_RESOLUTIONS = [step * 0.5 for step in range(24, 53)]  # 12.0 .. 26.0
 # erase/restriction vectors use 5 mm units: one header unit therefore equals
 # two vector units. Trace points use a separate 2.5 mm coordinate scale.
 _Q10_VECTOR_UNITS_PER_HEADER_RESOLUTION_UNIT = 2.0
+# The grid header's resolution is centimetres per pixel, while live trace
+# coordinates are 2.5 mm units. One header unit therefore spans four trace
+# units (5 cm/pixel -> 20 trace units/pixel for the observed resolution 5).
+_Q10_TRACE_UNITS_PER_HEADER_RESOLUTION_UNIT = 4.0
 # A path needs enough shape to constrain a full (origin + resolution) fit; a few
 # points cannot.
 _MIN_CALIBRATION_POINTS = 20
-# When the grid-frame header supplies the origin, only the resolution is fit, so
-# a much shorter path suffices to confirm it (early in a clean, not just a dense
-# one). See :func:`solve_calibration_with_origin`.
-_MIN_HEADER_CALIBRATION_POINTS = 4
 _Q10_DRAWABLE_TYPES = {
     Drawable.CHARGER,
     Drawable.NO_GO_AREAS,
@@ -162,30 +164,125 @@ def solve_q10_calibration(
 ) -> GridCalibration | None:
     """Derive world-to-pixel calibration from a map and its current trace.
 
-    When the map packet's grid-frame header carries a calibration origin (ss07),
-    only the resolution is fit -- around that fixed origin -- so a short path
-    suffices and the origin is exact rather than recovered by a slide. Otherwise
-    the full origin + resolution fit is used, which needs a reasonably dense
-    cleaning path. Returns ``None`` if the path is too short/featureless to fit.
+    When the map packet carries usable ss07 header metadata, its fixed origin
+    and resolution are authoritative and work from the first live pose. Older
+    or incomplete packets fall back to a full origin/resolution fit, which needs
+    a reasonably dense cleaning path. Returns ``None`` when neither is usable.
     """
-    if trace is None:
+    if trace is None or not trace.points:
         return None
+    if calibration := _trace_calibration_from_header_metadata(packet, trace.points):
+        return calibration
     points: list[tuple[float, float]] = [(point.x, point.y) for point in trace.points]
-    return _calibration_from_header(packet, points) or _calibration_from_fit(packet.layers, points)
+    return _calibration_from_fit(packet.layers, points)
 
 
-def _calibration_from_header(
+def _trace_calibration_from_header_metadata(
     packet: Q10MapPacket,
-    points: list[tuple[float, float]],
+    points: Sequence[Q10Point],
 ) -> GridCalibration | None:
-    """Calibrate around the header-supplied origin (resolution fit to a path)."""
-    header_calibration = packet.header_calibration
-    if header_calibration is None or len(points) < _MIN_HEADER_CALIBRATION_POINTS:
+    """Build the live-trace transform directly from validated header metadata."""
+    header = packet.header_calibration
+    if header is None or header.resolution <= 0 or (origin := header.origin_pixels()) is None:
         return None
-    origin = header_calibration.origin_pixels()
-    if origin is None:  # keepalive frame -- no usable origin
+    resolution = header.resolution * _Q10_TRACE_UNITS_PER_HEADER_RESOLUTION_UNIT
+    if not min(_Q10_RESOLUTIONS) <= resolution <= max(_Q10_RESOLUTIONS):
         return None
-    return solve_calibration_with_origin(packet.layers, points, origin, resolutions=_Q10_RESOLUTIONS)
+    calibration = GridCalibration(
+        resolution=resolution,
+        origin_x=origin[0],
+        origin_y=origin[1],
+        y_sign=1,
+    )
+    return calibration if _trace_projects_onto_floor(packet.layers, points, calibration) else None
+
+
+def _trace_projects_onto_floor(
+    layers: GridLayers,
+    points: Sequence[Q10Point],
+    calibration: GridCalibration,
+) -> bool:
+    """Validate header calibration against a bounded sample of trace points."""
+    if not points:
+        return False
+    stride = max(1, len(points) // 256)
+    sample = points[::stride]
+    on_floor = 0
+    for point in sample:
+        pixel_x, pixel_y = calibration.world_to_pixel(point.x, point.y)
+        if not math.isfinite(pixel_x) or not math.isfinite(pixel_y):
+            continue
+        column, row = math.floor(pixel_x), math.floor(pixel_y)
+        if not (0 <= column < layers.width and 0 <= row < layers.height):
+            continue
+        if layers.cell_class(layers.grid[row * layers.width + column]) == "floor":
+            on_floor += 1
+    return on_floor >= len(sample) * 0.5
+
+
+def _room_at_position(
+    packet: Q10MapPacket,
+    position: Q10Point,
+    calibration: GridCalibration,
+    *,
+    search_radius: int = 2,
+) -> Q10Room | None:
+    """Resolve a live position to a segmented room in the occupancy grid.
+
+    The exact cell wins. A robot centre can briefly land on a wall or doorway
+    pixel, so a small expanding neighbourhood is used only when the exact cell
+    is not segmented. Ambiguous ties stay unknown rather than naming the wrong
+    room.
+    """
+    pixel_x, pixel_y = calibration.world_to_pixel(position.x, position.y)
+    if not math.isfinite(pixel_x) or not math.isfinite(pixel_y):
+        return None
+    column, row = math.floor(pixel_x), math.floor(pixel_y)
+    if not (0 <= column < packet.width and 0 <= row < packet.height):
+        return None
+
+    rooms_by_value = {room.pixel_value: room for room in packet.rooms}
+
+    def room_at(column: int, row: int) -> Q10Room | None:
+        if not (0 <= column < packet.width and 0 <= row < packet.height):
+            return None
+        return rooms_by_value.get(packet.grid[row * packet.width + column])
+
+    if room := room_at(column, row):
+        return room
+
+    for radius in range(1, max(0, search_radius) + 1):
+        room_ids = {
+            candidate.id
+            for nearby_row in range(row - radius, row + radius + 1)
+            for nearby_column in range(column - radius, column + radius + 1)
+            if (candidate := room_at(nearby_column, nearby_row)) is not None
+        }
+        if not room_ids:
+            continue
+        if len(room_ids) != 1:
+            return None
+        room_id = room_ids.pop()
+        return next((room for room in packet.rooms if room.id == room_id), None)
+    return None
+
+
+def resolve_q10_current_room(packet: Q10MapPacket, trace: Q10TracePacket | None) -> Q10Room | None:
+    """Infer the robot's current room from its latest live pose and map grid.
+
+    No authoritative active-segment field has been identified or observed on
+    ss07 firmware. The live trace's final point is the robot pose, and the full
+    map labels every segmented floor cell. Header metadata supplies the fixed
+    transform from trace coordinates to that grid; older/incomplete packets
+    fall back to the path-fit calibration used by rendering.
+    """
+    if trace is None or (position := trace.robot_position) is None:
+        return None
+    calibration = solve_q10_calibration(packet, trace)
+    if calibration is None:
+        return None
+    room = _room_at_position(packet, position, calibration)
+    return replace(room) if room is not None else None
 
 
 def _calibration_from_header_metadata(

--- a/roborock/protocols/b01_q10_protocol.py
+++ b/roborock/protocols/b01_q10_protocol.py
@@ -10,8 +10,8 @@ from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import (
     Q10MapPacket,
     Q10TracePacket,
-    is_map_packet,
     is_trace_packet,
+    map_packet_kind,
     parse_map_packet,
     parse_trace_packet,
 )
@@ -113,16 +113,16 @@ Q10Message = Q10DpsUpdate | Q10MapPacket | Q10TracePacket
 def decode_message(message: RoborockMessage) -> Q10Message | None:
     """Decode a pushed Q10 ``RoborockMessage`` into a typed message.
 
-    ``MAP_RESPONSE`` (protocol 301) payloads carry the binary map (``01 01``) or
-    trace (``02 01``) packets, which are parsed by the map parser; any other
-    ``MAP_RESPONSE`` marker is unrecognized and yields ``None``. Every other
-    protocol is treated as a DPS status update.
+    ``MAP_RESPONSE`` (protocol 301) payloads carry binary current-map (``01
+    01``), trace (``02 01``), clean-record detail (``03 01``), or saved-map
+    detail (``04 01``) packets. Any other marker is unrecognized and yields
+    ``None``. Every other protocol is treated as a DPS status update.
 
     Raises ``RoborockException`` if a recognized payload fails to parse.
     """
     if message.protocol == RoborockMessageProtocol.MAP_RESPONSE:
         payload = message.payload or b""
-        if is_map_packet(payload):
+        if map_packet_kind(payload) is not None:
             return parse_map_packet(payload)
         if is_trace_packet(payload):
             return parse_trace_packet(payload)

--- a/roborock/protocols/b01_q10_protocol.py
+++ b/roborock/protocols/b01_q10_protocol.py
@@ -1,7 +1,10 @@
 """Roborock B01 Protocol encoding and decoding."""
 
+import base64
 import json
 import logging
+import struct
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -15,6 +18,7 @@ from roborock.map.b01_q10_map_parser import (
     parse_map_packet,
     parse_trace_packet,
 )
+from roborock.map.b01_q10_overlays import Q10RestrictedZone, Q10VirtualWall
 from roborock.roborock_message import (
     RoborockMessage,
     RoborockMessageProtocol,
@@ -24,6 +28,120 @@ _LOGGER = logging.getLogger(__name__)
 
 B01_VERSION = b"B01"
 ParamsType = list | dict | int | None
+_Q10_ZONE_RECORD_SIZE = 38
+_Q10_ROOM_NAME_FIELD_SIZE = 19
+
+
+def _orientation(a: tuple[int, int], b: tuple[int, int], c: tuple[int, int]) -> int:
+    return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+
+
+def _on_segment(a: tuple[int, int], b: tuple[int, int], point: tuple[int, int]) -> bool:
+    return min(a[0], b[0]) <= point[0] <= max(a[0], b[0]) and min(a[1], b[1]) <= point[1] <= max(a[1], b[1])
+
+
+def _segments_cross(a: tuple[int, int], b: tuple[int, int], c: tuple[int, int], d: tuple[int, int]) -> bool:
+    orientations = (
+        _orientation(a, b, c),
+        _orientation(a, b, d),
+        _orientation(c, d, a),
+        _orientation(c, d, b),
+    )
+    if orientations[0] * orientations[1] < 0 and orientations[2] * orientations[3] < 0:
+        return True
+    return any(
+        orientation == 0 and _on_segment(start, end, point)
+        for orientation, start, end, point in (
+            (orientations[0], a, b, c),
+            (orientations[1], a, b, d),
+            (orientations[2], c, d, a),
+            (orientations[3], c, d, b),
+        )
+    )
+
+
+def _validate_quadrilateral(vertices: list[tuple[int, int]]) -> None:
+    area_twice = sum(
+        x1 * y2 - x2 * y1 for (x1, y1), (x2, y2) in zip(vertices, (*vertices[1:], vertices[0]), strict=True)
+    )
+    if area_twice == 0:
+        raise ValueError("restricted-zone vertices must enclose an area")
+    if _segments_cross(vertices[0], vertices[1], vertices[2], vertices[3]) or _segments_cross(
+        vertices[1], vertices[2], vertices[3], vertices[0]
+    ):
+        raise ValueError("restricted-zone edges must not cross")
+
+
+def encode_restricted_zones(zones: Sequence[Q10RestrictedZone]) -> str:
+    """Encode the complete Q10 restricted-zone collection."""
+    if isinstance(zones, (str, bytes)) or len(zones) > 255:
+        raise ValueError("zones must be a sequence of at most 255 restrictions")
+    if not zones:
+        return base64.b64encode(b"\x01\x00").decode()
+
+    payload = bytearray((1, len(zones)))
+    for zone in zones:
+        if not isinstance(zone, Q10RestrictedZone):
+            raise ValueError("zones must contain Q10RestrictedZone values")
+        if isinstance(zone.type, bool) or not isinstance(zone.type, int) or not 0 <= zone.type <= 255:
+            raise ValueError("restricted-zone type must be an integer between 0 and 255")
+        if len(zone.vertices) != 4:
+            raise ValueError("restricted zones must contain exactly four vertices")
+        if len(set(zone.vertices)) != 4:
+            raise ValueError("restricted-zone vertices must be distinct")
+        record = bytearray((zone.type, len(zone.vertices)))
+        vector_vertices = [point.to_vector() for point in zone.vertices]
+        _validate_quadrilateral(vector_vertices)
+        for x, y in vector_vertices:
+            record.extend(
+                struct.pack(
+                    ">hh",
+                    x,
+                    y,
+                )
+            )
+        record.extend(bytes(_Q10_ZONE_RECORD_SIZE - len(record)))
+        payload.extend(record)
+    return base64.b64encode(payload).decode()
+
+
+def encode_virtual_walls(walls: Sequence[Q10VirtualWall]) -> str:
+    """Encode the complete Q10 virtual-wall collection."""
+    if isinstance(walls, (str, bytes)) or len(walls) > 255:
+        raise ValueError("walls must be a sequence of at most 255 virtual walls")
+
+    payload = bytearray((len(walls),))
+    for wall in walls:
+        if not isinstance(wall, Q10VirtualWall):
+            raise ValueError("walls must contain Q10VirtualWall values")
+        if wall.start == wall.end:
+            raise ValueError("virtual-wall endpoints must be distinct")
+        for point in (wall.start, wall.end):
+            x, y = point.to_vector()
+            payload.extend(
+                struct.pack(
+                    ">hh",
+                    x,
+                    y,
+                )
+            )
+    return base64.b64encode(payload).decode()
+
+
+def encode_room_name(room_id: int, name: str) -> str:
+    """Encode a Q10 room-name update."""
+    if isinstance(room_id, bool) or not isinstance(room_id, int) or not 0 <= room_id <= 255:
+        raise ValueError("room_id must be an integer between 0 and 255")
+    if not isinstance(name, str) or not name or "\x00" in name:
+        raise ValueError("name must be a non-empty string without null bytes")
+    encoded_name = name.encode("utf-8")
+    if len(encoded_name) > _Q10_ROOM_NAME_FIELD_SIZE:
+        raise ValueError("name must be at most 19 UTF-8 bytes")
+
+    payload = bytearray((1, room_id, 0, len(encoded_name)))
+    payload.extend(encoded_name)
+    payload.extend(bytes(_Q10_ROOM_NAME_FIELD_SIZE - len(encoded_name)))
+    return base64.b64encode(payload).decode()
 
 
 def encode_mqtt_payload(command: B01_Q10_DP, params: ParamsType) -> RoborockMessage:

--- a/tests/data/b01_q10/test_b01_q10_containers.py
+++ b/tests/data/b01_q10/test_b01_q10_containers.py
@@ -1,0 +1,63 @@
+"""Tests for B01 Q10 data containers."""
+
+from typing import Any
+
+import pytest
+
+from roborock.data.b01_q10.b01_q10_containers import Q10RoborockPoint
+
+
+@pytest.mark.parametrize(
+    ("vector", "roborock"),
+    [
+        ((0, 0), (25_500, 25_500)),
+        ((-1682, -1595), (17_090, 17_525)),
+        ((932, -925), (30_160, 20_875)),
+        ((-32_768, 32_767), (-138_340, 189_335)),
+        ((32_767, -32_768), (189_335, -138_340)),
+    ],
+)
+def test_q10_roborock_point_conversion_round_trip(vector: tuple[int, int], roborock: tuple[int, int]) -> None:
+    """Vector coordinates round-trip at the full signed-int16 boundaries."""
+    point = Q10RoborockPoint.from_vector(*vector)
+
+    assert (point.x, point.y) == roborock
+    assert point.to_vector() == vector
+
+
+@pytest.mark.parametrize(
+    ("x", "y"),
+    [
+        (True, 0),
+        (0, False),
+        (1.0, 0),
+        (0, 1.0),
+        ("1", 0),
+        (0, "1"),
+        (-32_769, 0),
+        (0, 32_768),
+    ],
+)
+def test_q10_roborock_point_from_vector_rejects_invalid_coordinates(x: Any, y: Any) -> None:
+    """Wire vectors must be real integers inside the signed-int16 range."""
+    with pytest.raises(ValueError, match="coordinates"):
+        Q10RoborockPoint.from_vector(x, y)
+
+
+@pytest.mark.parametrize(
+    ("x", "y", "message"),
+    [
+        (True, 25_500, "integers"),
+        (25_500, False, "integers"),
+        (25_500.0, 25_500, "integers"),
+        (25_500, "25500", "integers"),
+        (25_501, 25_500, "5 mm grid"),
+        (25_500, 25_499, "5 mm grid"),
+        (-138_345, 25_500, "outside"),
+        (25_500, 189_340, "outside"),
+    ],
+)
+def test_q10_roborock_point_to_vector_rejects_invalid_coordinates(x: Any, y: Any, message: str) -> None:
+    """Common coordinates must be aligned and encodable without wrapping."""
+    with pytest.raises(ValueError, match=message):
+        Q10RoborockPoint(x, y).to_vector()

--- a/tests/devices/test_device_manager.py
+++ b/tests/devices/test_device_manager.py
@@ -8,13 +8,16 @@ from unittest.mock import Mock, patch
 
 import pytest
 import syrupy
+from vacuum_map_parser_base.config.drawable import Drawable
 
 from roborock.data import HomeData, UserData
 from roborock.data.containers import HomeDataDevice, HomeDataProduct, RoborockCategory
 from roborock.devices.cache import InMemoryCache
 from roborock.devices.device import RoborockDevice
 from roborock.devices.device_manager import UserParams, create_device_manager, create_web_api_wrapper
+from roborock.devices.traits.b01.q10 import create as create_q10
 from roborock.exceptions import RoborockException, RoborockInvalidCredentials
+from roborock.map.map_parser import MapParserConfig
 from roborock.testing import FakeRoborockCloud, Q10VacuumSimulator, V1VacuumSimulator
 from tests import mock_data
 
@@ -85,7 +88,12 @@ async def test_with_q10_device(cloud: FakeRoborockCloud, patch_device_manager: N
     )
     cloud.add_device(q10_sim)
 
-    device_manager = await create_device_manager(USER_PARAMS)
+    map_parser_config = MapParserConfig(drawables=[Drawable.OBSTACLES], map_scale=2)
+    with patch("roborock.devices.device_manager.b01.q10.create", wraps=create_q10) as q10_create:
+        device_manager = await create_device_manager(USER_PARAMS, map_parser_config=map_parser_config)
+    q10_config = q10_create.call_args.kwargs["map_parser_config"]
+    assert q10_config.map_scale == 2
+    assert q10_config.drawables == [Drawable.OBSTACLES]
     devices = await device_manager.get_devices()
 
     # The setup includes fake_device (V1) by default because of the fake_device fixture

--- a/tests/devices/traits/b01/q10/__snapshots__/test_status.ambr
+++ b/tests/devices/traits/b01/q10/__snapshots__/test_status.ambr
@@ -24,6 +24,7 @@
       'dustSwitch': True,
     }),
     'map': dict({
+      'currentRoom': None,
       'obstacles': list([
       ]),
       'path': list([
@@ -406,6 +407,7 @@
         'dustSwitch': True,
       }),
       'map': dict({
+        'currentRoom': None,
         'obstacles': list([
         ]),
         'path': list([
@@ -484,6 +486,7 @@
     'dust_collection': dict({
     }),
     'map': dict({
+      'currentRoom': None,
       'obstacles': list([
       ]),
       'path': list([

--- a/tests/devices/traits/b01/q10/__snapshots__/test_status.ambr
+++ b/tests/devices/traits/b01/q10/__snapshots__/test_status.ambr
@@ -24,6 +24,8 @@
       'dustSwitch': True,
     }),
     'map': dict({
+      'obstacles': list([
+      ]),
       'path': list([
       ]),
       'robotHeading': None,
@@ -404,6 +406,8 @@
         'dustSwitch': True,
       }),
       'map': dict({
+        'obstacles': list([
+        ]),
         'path': list([
         ]),
         'robotHeading': None,
@@ -480,6 +484,8 @@
     'dust_collection': dict({
     }),
     'map': dict({
+      'obstacles': list([
+      ]),
       'path': list([
       ]),
       'robotHeading': None,

--- a/tests/devices/traits/b01/q10/test_clean_history.py
+++ b/tests/devices/traits/b01/q10/test_clean_history.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,7 @@ from roborock.data.b01_q10.b01_q10_containers import Q10CleanRecord
 from roborock.devices.traits.b01.q10 import Q10PropertiesApi
 from roborock.devices.traits.b01.q10.clean_history import CleanHistoryTrait, CleanRecordConverter
 from roborock.exceptions import RoborockException
-from roborock.map.b01_q10_map_parser import parse_map_packet
+from roborock.map.b01_q10_map_parser import Q10Obstacle, parse_map_packet
 
 from .conftest import FakeB01Q10Channel
 
@@ -228,3 +229,18 @@ async def test_detail_response_is_associated_with_pending_record(
 
     assert clean_history.detail_record is record
     assert clean_history.detail_packet is packet
+
+
+def test_clean_record_detail_exposes_obstacles(clean_history: CleanHistoryTrait) -> None:
+    fixture = Path("tests/map/testdata/b01_q10_map.bin").read_bytes()
+    packet = replace(
+        parse_map_packet(b"\x03\x01" + fixture[2:]),
+        obstacles=[Q10Obstacle(100, -200), Q10Obstacle(-300, 400)],
+    )
+
+    clean_history.update_from_map_packet(packet)
+
+    assert clean_history.detail_obstacles == packet.obstacles
+    exposed = clean_history.detail_obstacles
+    exposed.clear()
+    assert clean_history.detail_obstacles == packet.obstacles

--- a/tests/devices/traits/b01/q10/test_clean_history.py
+++ b/tests/devices/traits/b01/q10/test_clean_history.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from roborock.data.b01_q10.b01_q10_code_mappings import (
@@ -10,6 +12,8 @@ from roborock.data.b01_q10.b01_q10_code_mappings import (
 from roborock.data.b01_q10.b01_q10_containers import Q10CleanRecord
 from roborock.devices.traits.b01.q10 import Q10PropertiesApi
 from roborock.devices.traits.b01.q10.clean_history import CleanHistoryTrait, CleanRecordConverter
+from roborock.exceptions import RoborockException
+from roborock.map.b01_q10_map_parser import parse_map_packet
 
 from .conftest import FakeB01Q10Channel
 
@@ -175,3 +179,52 @@ async def test_refresh_sends_op_list(q10_api: Q10PropertiesApi, fake_channel: Fa
         B01_Q10_DP.COMMON,
         {"52": {"op": "list"}},
     )
+
+
+async def test_refresh_detail_sends_full_raw_record(
+    clean_history: CleanHistoryTrait,
+    fake_channel: FakeB01Q10Channel,
+) -> None:
+    record = CleanRecordConverter.parse_record(RECORD_A)
+    assert record is not None
+
+    await clean_history.refresh_detail(record)
+
+    assert fake_channel.published_commands == [
+        (
+            B01_Q10_DP.COMMON,
+            {"52": {"op": "select", "id": RECORD_A}},
+        )
+    ]
+
+
+async def test_refresh_detail_rejects_record_without_map(clean_history: CleanHistoryTrait) -> None:
+    record = CleanRecordConverter.parse_record("x_1781226271_1_1_0_0_0_0_2_1_1_0")
+    assert record is not None
+
+    with pytest.raises(RoborockException, match="no saved map detail"):
+        await clean_history.refresh_detail(record)
+
+
+async def test_refresh_detail_rejects_parallel_request(clean_history: CleanHistoryTrait) -> None:
+    record = CleanRecordConverter.parse_record(RECORD_A)
+    assert record is not None
+    await clean_history.refresh_detail(record)
+
+    with pytest.raises(RoborockException, match="already pending"):
+        await clean_history.refresh_detail(record)
+
+
+async def test_detail_response_is_associated_with_pending_record(
+    clean_history: CleanHistoryTrait,
+) -> None:
+    record = CleanRecordConverter.parse_record(RECORD_A)
+    assert record is not None
+    await clean_history.refresh_detail(record)
+    fixture = Path("tests/map/testdata/b01_q10_map.bin").read_bytes()
+    packet = parse_map_packet(b"\x03\x01" + fixture[2:])
+
+    clean_history.update_from_map_packet(packet)
+
+    assert clean_history.detail_record is record
+    assert clean_history.detail_packet is packet

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -17,6 +17,7 @@ import pytest
 
 from roborock.cli import _await_q10_map_push, cli
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXDeviceState
+from roborock.data.b01_q10.b01_q10_containers import Q10RoborockPoint
 from roborock.devices.traits.b01.q10 import Q10PropertiesApi, create
 from roborock.devices.traits.b01.q10.command import CommandTrait
 from roborock.devices.traits.b01.q10.map import MapContentTrait, MapDpsTrait
@@ -30,6 +31,11 @@ from roborock.map.b01_q10_map_parser import (
     Q10TracePacket,
     parse_map_packet,
     parse_trace_packet,
+)
+from roborock.map.b01_q10_overlays import (
+    Q10RestrictedZone,
+    Q10RestrictionType,
+    Q10VirtualWall,
 )
 from roborock.map.b01_q10_render import Q10MapOverlays
 from roborock.protocols.b01_q10_protocol import Q10DpsUpdate, Q10Message
@@ -692,6 +698,49 @@ async def test_saved_map_detail_refresh_accepts_any_listed_map_id(q10_api: Q10Pr
     )
 
 
+async def test_set_current_map_uses_apply_for_listed_string_id(q10_api: Q10PropertiesApi) -> None:
+    q10_api.maps.update_from_dps(
+        {
+            B01_Q10_DP.MULTI_MAP: {
+                "data": [{"id": "12345"}, {"id": "67890"}],
+                "op": "list",
+                "result": 1,
+            }
+        }
+    )
+
+    with patch.object(q10_api.command, "send") as send:
+        await q10_api.maps.set_current_map("67890")
+
+    send.assert_awaited_once_with(
+        B01_Q10_DP.COMMON,
+        {str(B01_Q10_DP.MULTI_MAP.code): {"op": "apply", "id": "67890"}},
+    )
+    assert q10_api.maps.current_map_id == "12345"
+
+
+@pytest.mark.parametrize("map_id", ["999", 12345])
+async def test_set_current_map_rejects_unknown_or_non_string_id(
+    q10_api: Q10PropertiesApi,
+    map_id: object,
+) -> None:
+    q10_api.maps.update_from_dps(
+        {
+            B01_Q10_DP.MULTI_MAP: {
+                "data": [{"id": "12345"}],
+                "op": "list",
+                "result": 1,
+            }
+        }
+    )
+
+    with patch.object(q10_api.command, "send") as send:
+        with pytest.raises(RoborockException, match="Unknown Q10 saved-map ID"):
+            await q10_api.maps.set_current_map(map_id)  # type: ignore[arg-type]
+
+    send.assert_not_awaited()
+
+
 async def test_saved_map_detail_refresh_rejects_unknown_or_parallel_request(
     q10_api: Q10PropertiesApi,
 ) -> None:
@@ -830,6 +879,143 @@ def test_map_dps_update_renders_decoded_overlays(render_map: Mock) -> None:
     assert render_map.call_args.args[0] is packet
     assert render_map.call_args.args[1] is None
     assert render_map.call_args.args[2] is map_dps.overlays
+
+
+def test_map_content_exposes_restrictions_in_common_coordinates() -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+
+    map_dps.update_from_dps(
+        {
+            B01_Q10_DP.RESTRICTED_ZONE_UP: _zone_blob(),
+            B01_Q10_DP.VIRTUAL_WALL_UP: "AQAAAAAACgAU",
+        }
+    )
+
+    assert trait.restricted_zones == (
+        Q10RestrictedZone(
+            Q10RestrictionType.NO_GO,
+            (
+                Q10RoborockPoint(25500, 25500),
+                Q10RoborockPoint(25700, 25500),
+                Q10RoborockPoint(25700, 25700),
+                Q10RoborockPoint(25500, 25700),
+            ),
+        ),
+    )
+    assert trait.virtual_walls == (
+        Q10VirtualWall(
+            start=Q10RoborockPoint(25500, 25500),
+            end=Q10RoborockPoint(25550, 25600),
+        ),
+    )
+
+
+def test_map_content_preserves_unknown_restriction_type() -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    raw = bytearray(base64.b64decode(_zone_blob()))
+    raw[2] = 42
+
+    map_dps.update_from_dps({B01_Q10_DP.RESTRICTED_ZONE_UP: base64.b64encode(raw).decode()})
+
+    assert trait.restricted_zones[0].type == 42
+
+
+async def test_set_restricted_zones_sends_atomic_common_write(q10_api: Q10PropertiesApi) -> None:
+    q10_api._map_dps.update_from_dps({B01_Q10_DP.RESTRICTED_ZONE_UP: "AQA="})
+    zone = Q10RestrictedZone(
+        Q10RestrictionType.NO_MOP,
+        (
+            Q10RoborockPoint(25500, 25500),
+            Q10RoborockPoint(25550, 25500),
+            Q10RoborockPoint(25550, 25550),
+            Q10RoborockPoint(25500, 25550),
+        ),
+    )
+
+    with patch.object(q10_api.command, "send") as send:
+        await q10_api.map.set_restricted_zones([zone])
+
+    send.assert_awaited_once_with(
+        B01_Q10_DP.COMMON,
+        {str(B01_Q10_DP.RESTRICTED_ZONE.code): "AQECBAAAAAAACgAAAAoACgAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAA=="},
+    )
+    assert q10_api.map.restricted_zones == ()
+
+
+async def test_set_virtual_walls_sends_atomic_common_write(q10_api: Q10PropertiesApi) -> None:
+    wall = Q10VirtualWall(
+        start=Q10RoborockPoint(25450, 25500),
+        end=Q10RoborockPoint(25550, 25600),
+    )
+
+    with patch.object(q10_api.command, "send") as send:
+        await q10_api.map.set_virtual_walls((wall,))
+
+    send.assert_awaited_once_with(
+        B01_Q10_DP.COMMON,
+        {str(B01_Q10_DP.VIRTUAL_WALL.code): "Af/2AAAACgAU"},
+    )
+    assert q10_api.map.virtual_walls == ()
+
+
+async def test_invalid_map_control_does_not_publish(q10_api: Q10PropertiesApi) -> None:
+    invalid = Q10VirtualWall(
+        start=Q10RoborockPoint(25501, 25500),
+        end=Q10RoborockPoint(25550, 25600),
+    )
+
+    with patch.object(q10_api.command, "send") as send:
+        with pytest.raises(ValueError, match="5 mm grid"):
+            await q10_api.map.set_virtual_walls([invalid])
+
+    send.assert_not_awaited()
+
+
+async def test_restriction_write_refuses_unrepresentable_device_polygon(q10_api: Q10PropertiesApi) -> None:
+    vertices = ((0, 0), (10, 0), (15, 5), (10, 10), (0, 10))
+    record = bytes((0, len(vertices))) + b"".join(
+        value.to_bytes(2, "big", signed=True) for point in vertices for value in point
+    )
+    q10_api._map_dps.update_from_dps({B01_Q10_DP.RESTRICTED_ZONE_UP: base64.b64encode(bytes((1, 1)) + record).decode()})
+
+    with patch.object(q10_api.command, "send") as send:
+        with pytest.raises(RoborockException, match="fully supported device snapshot"):
+            await q10_api.map.set_restricted_zones([])
+
+    send.assert_not_awaited()
+
+
+async def test_restriction_write_requires_device_snapshot(q10_api: Q10PropertiesApi) -> None:
+    with patch.object(q10_api.command, "send") as send:
+        with pytest.raises(RoborockException, match="fully supported device snapshot"):
+            await q10_api.map.set_restricted_zones([])
+
+    send.assert_not_awaited()
+
+
+async def test_set_room_name_sends_validated_common_write(q10_api: Q10PropertiesApi) -> None:
+    q10_api.map.update_from_map_packet(parse_map_packet(FIXTURE.read_bytes()))
+
+    with patch.object(q10_api.command, "send") as send:
+        await q10_api.map.set_room_name(2, "Study")
+
+    send.assert_awaited_once_with(
+        B01_Q10_DP.COMMON,
+        {str(B01_Q10_DP.RESET_ROOM_NAME.code): "AQIABVN0dWR5AAAAAAAAAAAAAAAAAAA="},
+    )
+    assert q10_api.map.rooms[0].raw_name == "rr_living_room"
+
+
+async def test_set_room_name_rejects_unknown_room_before_publish(q10_api: Q10PropertiesApi) -> None:
+    q10_api.map.update_from_map_packet(parse_map_packet(FIXTURE.read_bytes()))
+
+    with patch.object(q10_api.command, "send") as send:
+        with pytest.raises(RoborockException, match="Unknown Q10 room ID"):
+            await q10_api.map.set_room_name(99, "Study")
+
+    send.assert_not_awaited()
 
 
 def test_map_dps_blobs_are_decoded_only_when_dps_arrives() -> None:

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -1,9 +1,8 @@
 """Tests for the Q10 B01 map content trait.
 
-Map list data and map content have independent refresh schedules. Content
-requests use a stored map ID, and the device sends the data later in a
-``MAP_RESPONSE`` packet. These tests cover that state management. The render
-details are tested in ``tests/map/test_b01_q10_render.py``.
+Map list data and current-map content have independent refresh schedules. The
+device sends map data later in a ``MAP_RESPONSE`` packet. These tests cover
+that state management; rendering is tested separately.
 """
 
 import asyncio
@@ -23,6 +22,7 @@ from roborock.devices.traits.b01.q10.map import MapContentTrait, MapDpsTrait
 from roborock.devices.traits.b01.q10.maps import MapsTrait
 from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import (
+    B01Q10MapParserConfig,
     Q10MapPacketKind,
     Q10Point,
     Q10TracePacket,
@@ -39,19 +39,9 @@ TRACE_SESSION_FIXTURE = Path("tests/map/testdata/b01_q10_trace_session.bin")
 
 
 def _map_trait(map_dps: MapDpsTrait | None = None) -> MapContentTrait:
-    """Create map content with a stored map ID for tests that do not perform I/O."""
+    """Create map content for tests that do not perform I/O."""
     command = cast(CommandTrait, Mock(spec=CommandTrait))
-    maps = MapsTrait(command)
-    maps.update_from_dps(
-        {
-            B01_Q10_DP.MULTI_MAP: {
-                "data": [{"id": "12345"}],
-                "op": "list",
-                "result": 1,
-            }
-        }
-    )
-    return MapContentTrait(map_dps or MapDpsTrait(), maps, command)
+    return MapContentTrait(map_dps or MapDpsTrait(), command)
 
 
 def _zone_blob() -> str:
@@ -130,7 +120,7 @@ class _FakeQ10Properties:
                 }
             }
         )
-        self.map = MapContentTrait(MapDpsTrait(), self.maps, command)
+        self.map = MapContentTrait(MapDpsTrait(), command)
         self.refresh_count = 0
 
         async def refresh_map() -> None:
@@ -158,6 +148,7 @@ async def test_await_q10_map_push_waits_for_fresh_update() -> None:
     got_trace = await _await_q10_map_push(
         cast(Q10PropertiesApi, properties),
         lambda: bool(properties.map.path),
+        lambda: properties.map.trace_revision,
         timeout=0.01,
     )
 
@@ -171,6 +162,7 @@ async def test_await_q10_map_push_returns_true_after_update() -> None:
     got_trace = await _await_q10_map_push(
         cast(Q10PropertiesApi, properties),
         lambda: bool(properties.map.path),
+        lambda: properties.map.trace_revision,
         timeout=0.01,
     )
 
@@ -185,6 +177,7 @@ async def test_await_q10_map_push_can_fall_back_to_cached_map_on_timeout() -> No
     got_map = await _await_q10_map_push(
         cast(Q10PropertiesApi, properties),
         lambda: properties.map.image_content is not None,
+        lambda: properties.map.map_revision,
         timeout=0.01,
         allow_cached_on_timeout=True,
     )
@@ -294,6 +287,30 @@ def test_archive_owners_reject_wrong_packet_kinds(q10_api: Q10PropertiesApi) -> 
         q10_api.clean_history.update_from_map_packet(current)
     with pytest.raises(ValueError, match="saved-map detail"):
         q10_api.maps.update_from_map_packet(current)
+
+
+def test_all_q10_map_views_share_the_injected_render_config(
+    fake_channel: FakeB01Q10Channel,
+) -> None:
+    config = B01Q10MapParserConfig(map_scale=2)
+    api = Q10PropertiesApi(fake_channel, map_parser_config=config)
+    payload = FIXTURE.read_bytes()
+
+    with (
+        patch("roborock.devices.traits.b01.q10.map.render_q10_map", return_value=b"map") as live_render,
+        patch(
+            "roborock.devices.traits.b01.q10.clean_history.render_q10_map",
+            return_value=b"history",
+        ) as history_render,
+        patch("roborock.devices.traits.b01.q10.maps.render_q10_map", return_value=b"saved") as saved_render,
+    ):
+        api._handle_message(parse_map_packet(payload))
+        api._handle_message(parse_map_packet(b"\x03\x01" + payload[2:]))
+        api._handle_message(parse_map_packet(b"\x04\x01" + payload[2:]))
+
+    assert live_render.call_args.kwargs["config"] is config
+    assert history_render.call_args.kwargs["config"] is config
+    assert saved_render.call_args.kwargs["config"] is config
 
 
 async def test_subscribe_loop_routes_trace_push(
@@ -416,6 +433,80 @@ async def test_saved_map_detail_refresh_uses_current_map_id(q10_api: Q10Properti
         B01_Q10_DP.COMMON,
         {str(B01_Q10_DP.MULTI_MAP.code): {"op": "select", "id": "12345"}},
     )
+
+
+async def test_saved_map_detail_refresh_accepts_any_listed_map_id(q10_api: Q10PropertiesApi) -> None:
+    q10_api.maps.update_from_dps(
+        {
+            B01_Q10_DP.MULTI_MAP: {
+                "data": [{"id": "12345"}, {"id": "67890"}],
+                "op": "list",
+                "result": 1,
+            }
+        }
+    )
+    assert [map_info.id for map_info in q10_api.maps.map_list] == ["12345", "67890"]
+
+    with patch.object(q10_api.command, "send") as send:
+        await q10_api.maps.refresh_detail("67890")
+
+    send.assert_awaited_once_with(
+        B01_Q10_DP.COMMON,
+        {str(B01_Q10_DP.MULTI_MAP.code): {"op": "select", "id": "67890"}},
+    )
+
+
+async def test_saved_map_detail_refresh_rejects_unknown_or_parallel_request(
+    q10_api: Q10PropertiesApi,
+) -> None:
+    q10_api.maps.update_from_dps(
+        {
+            B01_Q10_DP.MULTI_MAP: {
+                "data": [{"id": "12345"}],
+                "op": "list",
+                "result": 1,
+            }
+        }
+    )
+    with pytest.raises(RoborockException, match="Unknown Q10 saved-map ID"):
+        await q10_api.maps.refresh_detail("67890")
+
+    await q10_api.maps.refresh_detail("12345")
+    with pytest.raises(RoborockException, match="already pending"):
+        await q10_api.maps.refresh_detail("12345")
+
+
+async def test_saved_map_detail_correlates_pending_map_id(q10_api: Q10PropertiesApi) -> None:
+    requested_id = str(parse_map_packet(FIXTURE.read_bytes()).map_id)
+    q10_api.maps.update_from_dps(
+        {
+            B01_Q10_DP.MULTI_MAP: {
+                "data": [{"id": requested_id}, {"id": "999"}],
+                "op": "list",
+                "result": 1,
+            }
+        }
+    )
+
+    await q10_api.maps.refresh_detail("999")
+    packet = parse_map_packet(b"\x04\x01" + FIXTURE.read_bytes()[2:])
+    q10_api.maps.update_from_map_packet(packet)
+    assert q10_api.maps.detail_packet is None
+
+    matching = MapsTrait(q10_api.command)
+    matching.update_from_dps(
+        {
+            B01_Q10_DP.MULTI_MAP: {
+                "data": [{"id": requested_id}],
+                "op": "list",
+                "result": 1,
+            }
+        }
+    )
+    await matching.refresh_detail(requested_id)
+    matching.update_from_map_packet(packet)
+    assert matching.detail_packet is packet
+    assert matching.detail_map_id == requested_id
 
 
 async def test_saved_map_detail_refresh_requires_stored_map_id(q10_api: Q10PropertiesApi) -> None:
@@ -581,8 +672,8 @@ async def test_charging_status_renders_robot_at_dock(render_map: Mock) -> None:
     assert render_map.call_args.kwargs["robot_at_dock"] is True
 
 
-def test_docked_state_hides_trace_only_from_rendering(render_map: Mock) -> None:
-    """A docked render omits the valid trace without deleting source data."""
+def test_docked_state_clears_stale_live_trace(render_map: Mock) -> None:
+    """A docked update removes a completed path from public live state."""
     map_dps = MapDpsTrait()
     trait = _map_trait(map_dps)
     packet = parse_map_packet(FIXTURE.read_bytes())
@@ -595,13 +686,13 @@ def test_docked_state_hides_trace_only_from_rendering(render_map: Mock) -> None:
 
     map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CHARGING.code})
 
-    assert trait.path == trace.points
+    assert trait.path == []
     assert render_map.call_args.args[1] is None
     assert render_map.call_args.kwargs["robot_at_dock"] is True
 
 
-def test_late_trace_is_retained_but_hidden_while_docked(render_map: Mock) -> None:
-    """A late trace stays available but is not part of a docked render."""
+def test_late_trace_is_ignored_while_docked(render_map: Mock) -> None:
+    """A delayed trace cannot repopulate public state while docked."""
     map_dps = MapDpsTrait()
     map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CHARGING.code})
     trait = _map_trait(map_dps)
@@ -611,7 +702,7 @@ def test_late_trace_is_retained_but_hidden_while_docked(render_map: Mock) -> Non
     trait.update_from_map_packet(parse_map_packet(FIXTURE.read_bytes()))
     trait.update_from_trace_packet(trace)
 
-    assert trait.path == trace.points
+    assert trait.path == []
     assert render_map.call_args.args[1] is None
 
 

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -23,6 +23,7 @@ from roborock.devices.traits.b01.q10.map import MapContentTrait, MapDpsTrait
 from roborock.devices.traits.b01.q10.maps import MapsTrait
 from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import (
+    Q10MapPacketKind,
     Q10Point,
     Q10TracePacket,
     parse_map_packet,
@@ -81,6 +82,15 @@ def test_update_from_map_packet_populates_image_and_rooms() -> None:
     assert trait.image_content[:8] == b"\x89PNG\r\n\x1a\n"
     assert {room.id: room.name for room in trait.rooms} == {2: "Living Room", 3: "Bedroom"}
     assert len(updates) == 1
+
+
+def test_live_map_trait_rejects_archived_packet() -> None:
+    """Direct callers cannot bypass API routing and replace live map state."""
+    payload = FIXTURE.read_bytes()
+    archived = parse_map_packet(b"\x03\x01" + payload[2:])
+
+    with pytest.raises(ValueError, match="Expected a current Q10 map packet"):
+        _map_trait().update_from_map_packet(archived)
 
 
 def test_update_from_trace_packet_populates_path_and_position() -> None:
@@ -273,6 +283,62 @@ async def test_subscribe_loop_routes_map_push(
     assert {room.id: room.name for room in q10_api.map.rooms} == {2: "Living Room", 3: "Bedroom"}
 
 
+async def test_archived_map_pushes_cannot_overwrite_live_map(
+    q10_api: Q10PropertiesApi,
+    message_queue: asyncio.Queue[Q10Message],
+) -> None:
+    """03/04 detail packets are isolated from the current live-map trait."""
+    current_bytes = FIXTURE.read_bytes()
+    current = parse_map_packet(current_bytes)
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    clean_record = parse_map_packet(b"\x03\x01" + current_bytes[2:])
+    saved_map = parse_map_packet(b"\x04\x01" + current_bytes[2:])
+
+    message_queue.put_nowait(current)
+    message_queue.put_nowait(trace)
+    await _wait_for(lambda: q10_api.map.image_content is not None and bool(q10_api.map.path))
+    live_image = q10_api.map.image_content
+    live_rooms = list(q10_api.map.rooms)
+    live_path = list(q10_api.map.path)
+    live_position = q10_api.map.robot_position
+    live_heading = q10_api.map.robot_heading
+    live_updates: list[None] = []
+    clean_record_updates: list[None] = []
+    saved_map_updates: list[None] = []
+    q10_api.map.add_update_listener(lambda: live_updates.append(None))
+    q10_api.clean_history.add_update_listener(lambda: clean_record_updates.append(None))
+    q10_api.maps.add_update_listener(lambda: saved_map_updates.append(None))
+
+    message_queue.put_nowait(clean_record)
+    message_queue.put_nowait(saved_map)
+    await _wait_for(lambda: q10_api.maps.detail_packet is not None)
+
+    assert q10_api.map.image_content == live_image
+    assert q10_api.map.rooms == live_rooms
+    assert q10_api.map.path == live_path
+    assert q10_api.map.robot_position == live_position
+    assert q10_api.map.robot_heading == live_heading
+    assert live_updates == []
+    assert q10_api.clean_history.detail_packet is not None
+    assert q10_api.clean_history.detail_packet.kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL
+    assert q10_api.clean_history.detail_image_content is not None
+    assert q10_api.maps.detail_packet is not None
+    assert q10_api.maps.detail_packet.kind is Q10MapPacketKind.SAVED_MAP_DETAIL
+    assert q10_api.maps.detail_image_content is not None
+    assert clean_record_updates == [None]
+    assert saved_map_updates == [None]
+
+
+def test_archive_owners_reject_wrong_packet_kinds(q10_api: Q10PropertiesApi) -> None:
+    """Semantic archive traits reject packets owned by another map stream."""
+    current = parse_map_packet(FIXTURE.read_bytes())
+
+    with pytest.raises(ValueError, match="clean-record detail"):
+        q10_api.clean_history.update_from_map_packet(current)
+    with pytest.raises(ValueError, match="saved-map detail"):
+        q10_api.maps.update_from_map_packet(current)
+
+
 async def test_subscribe_loop_routes_trace_push(
     q10_api: Q10PropertiesApi,
     message_queue: asyncio.Queue[Q10Message],
@@ -377,6 +443,32 @@ async def test_map_content_refresh_requests_are_not_rate_limited(q10_api: Q10Pro
         await q10_api.map.refresh()
 
     assert send.await_count == 2
+
+
+async def test_saved_map_detail_refresh_uses_current_map_id(q10_api: Q10PropertiesApi) -> None:
+    """Saved-map detail uses the independently validated select request."""
+    q10_api.maps.update_from_dps(
+        {
+            B01_Q10_DP.MULTI_MAP: {
+                "data": [{"id": "12345"}],
+                "op": "list",
+                "result": 1,
+            }
+        }
+    )
+    with patch.object(q10_api.command, "send") as send:
+        await q10_api.maps.refresh_detail()
+
+    send.assert_awaited_once_with(
+        B01_Q10_DP.COMMON,
+        {str(B01_Q10_DP.MULTI_MAP.code): {"op": "select", "id": "12345"}},
+    )
+
+
+async def test_saved_map_detail_refresh_requires_stored_map_id(q10_api: Q10PropertiesApi) -> None:
+    """Detail cannot be requested until the saved-map list supplies an ID."""
+    with pytest.raises(RoborockException, match="map list is available"):
+        await q10_api.maps.refresh_detail()
 
 
 def test_map_get_ack_does_not_replace_saved_map_list(q10_api: Q10PropertiesApi) -> None:

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -8,6 +8,7 @@ that state management; rendering is tested separately.
 import asyncio
 import base64
 from collections.abc import AsyncGenerator, Generator
+from dataclasses import replace
 from pathlib import Path
 from typing import cast
 from unittest.mock import Mock, patch
@@ -24,6 +25,7 @@ from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import (
     B01Q10MapParserConfig,
     Q10MapPacketKind,
+    Q10Obstacle,
     Q10Point,
     Q10TracePacket,
     parse_map_packet,
@@ -72,6 +74,26 @@ def test_update_from_map_packet_populates_image_and_rooms() -> None:
     assert trait.image_content[:8] == b"\x89PNG\r\n\x1a\n"
     assert {room.id: room.name for room in trait.rooms} == {2: "Living Room", 3: "Bedroom"}
     assert len(updates) == 1
+
+
+def test_update_from_map_packet_exposes_obstacles() -> None:
+    """Live callers receive the same decoded obstacles used by rendering."""
+    packet = replace(
+        parse_map_packet(FIXTURE.read_bytes()),
+        obstacles=[Q10Obstacle(250, -300), Q10Obstacle(-50, 100)],
+    )
+    trait = _map_trait()
+
+    trait.update_from_map_packet(packet)
+
+    assert trait.obstacles == packet.obstacles
+    assert trait.as_dict()["obstacles"] == [
+        {"x": 250, "y": -300},
+        {"x": -50, "y": 100},
+    ]
+    exposed = trait.obstacles
+    exposed.clear()
+    assert trait.obstacles == packet.obstacles
 
 
 def test_live_map_trait_rejects_archived_packet() -> None:
@@ -287,6 +309,21 @@ def test_archive_owners_reject_wrong_packet_kinds(q10_api: Q10PropertiesApi) -> 
         q10_api.clean_history.update_from_map_packet(current)
     with pytest.raises(ValueError, match="saved-map detail"):
         q10_api.maps.update_from_map_packet(current)
+
+
+def test_saved_map_detail_exposes_obstacles(q10_api: Q10PropertiesApi) -> None:
+    payload = FIXTURE.read_bytes()
+    packet = replace(
+        parse_map_packet(b"\x04\x01" + payload[2:]),
+        obstacles=[Q10Obstacle(100, -200)],
+    )
+
+    q10_api.maps.update_from_map_packet(packet)
+
+    assert q10_api.maps.detail_obstacles == packet.obstacles
+    exposed = q10_api.maps.detail_obstacles
+    exposed.clear()
+    assert q10_api.maps.detail_obstacles == packet.obstacles
 
 
 def test_all_q10_map_views_share_the_injected_render_config(

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -150,34 +150,6 @@ class _FakeQ10PropertiesWithTrace(_FakeQ10Properties):
         self.map.refresh = refresh_map  # type: ignore[method-assign]
 
 
-class _FakeQ10PropertiesWithoutMapId:
-    def __init__(self) -> None:
-        command = cast(CommandTrait, Mock(spec=CommandTrait))
-        self.maps = MapsTrait(command)
-        self.map = MapContentTrait(MapDpsTrait(), self.maps, command)
-        self.maps_refresh_count = 0
-        self.map_refresh_count = 0
-
-        async def refresh_maps() -> None:
-            self.maps_refresh_count += 1
-            self.maps.update_from_dps(
-                {
-                    B01_Q10_DP.MULTI_MAP: {
-                        "data": [{"id": "12345"}],
-                        "op": "list",
-                        "result": 1,
-                    }
-                }
-            )
-
-        async def refresh_map() -> None:
-            self.map_refresh_count += 1
-            self.map.update_from_trace_packet(parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes()))
-
-        self.maps.refresh = refresh_maps  # type: ignore[method-assign]
-        self.map.refresh = refresh_map  # type: ignore[method-assign]
-
-
 async def test_await_q10_map_push_waits_for_fresh_update() -> None:
     """A cached trace alone is not treated as a successful new map push."""
     properties = _FakeQ10Properties()
@@ -204,21 +176,6 @@ async def test_await_q10_map_push_returns_true_after_update() -> None:
 
     assert got_trace is True
     assert len(properties.map.path) == 14
-
-
-async def test_await_q10_map_push_requests_map_list_only_on_first_use() -> None:
-    """Content gets the list first only when no stored map ID is available."""
-    properties = _FakeQ10PropertiesWithoutMapId()
-
-    got_trace = await _await_q10_map_push(
-        cast(Q10PropertiesApi, properties),
-        lambda: bool(properties.map.path),
-        timeout=0.01,
-    )
-
-    assert got_trace is True
-    assert properties.maps_refresh_count == 1
-    assert properties.map_refresh_count == 1
 
 
 async def test_await_q10_map_push_can_fall_back_to_cached_map_on_timeout() -> None:
@@ -352,7 +309,7 @@ async def test_subscribe_loop_routes_trace_push(
     assert q10_api.map.robot_position is not None
 
 
-async def test_map_list_and_content_refresh_are_independent(
+async def test_map_list_and_current_content_refresh_are_independent(
     q10_api: Q10PropertiesApi,
     mock_channel: FakeB01Q10Channel,
     message_queue: asyncio.Queue[Q10Message],
@@ -386,15 +343,7 @@ async def test_map_list_and_content_refresh_are_independent(
 
     await q10_api.map.refresh()
 
-    assert mock_channel.published_commands[1] == (
-        B01_Q10_DP.COMMON,
-        {
-            str(B01_Q10_DP.MULTI_MAP.code): {
-                "op": "get",
-                "id": "12345",
-            }
-        },
-    )
+    assert mock_channel.published_commands[1] == (B01_Q10_DP.REQUEST_DPS, {})
     assert q10_api.maps.current_map_id == "12345"
 
 
@@ -421,10 +370,14 @@ async def test_empty_map_list_does_not_request_content(
     assert mock_channel.published_commands == []
 
 
-async def test_map_content_refresh_requires_stored_map_id(q10_api: Q10PropertiesApi) -> None:
-    """Content cannot be requested until the map list supplies an ID."""
-    with pytest.raises(RoborockException, match="map list is available"):
-        await q10_api.map.refresh()
+async def test_map_content_refresh_does_not_require_stored_map_id(
+    q10_api: Q10PropertiesApi,
+    mock_channel: FakeB01Q10Channel,
+) -> None:
+    """Current-map refresh is read-only and independent of saved-map state."""
+    await q10_api.map.refresh()
+
+    assert mock_channel.published_commands == [(B01_Q10_DP.REQUEST_DPS, {})]
 
 
 async def test_map_content_refresh_requests_are_not_rate_limited(q10_api: Q10PropertiesApi) -> None:

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -72,7 +72,7 @@ def test_update_from_map_packet_populates_image_and_rooms() -> None:
 
     assert trait.image_content is not None
     assert trait.image_content[:8] == b"\x89PNG\r\n\x1a\n"
-    assert {room.id: room.name for room in trait.rooms} == {2: "Living Room", 3: "Bedroom"}
+    assert {room.id: room.name for room in trait.rooms} == {2: "Living Room", 3: "bedroom"}
     assert len(updates) == 1
 
 
@@ -120,6 +120,184 @@ def test_update_from_trace_packet_populates_path_and_position() -> None:
     assert (trait.robot_position.x, trait.robot_position.y) == (276, -1)
     assert trait.robot_heading == -34
     assert len(updates) == 1
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        YXDeviceState.CLEANING,
+        YXDeviceState.SWEEPING,
+        YXDeviceState.MOPPING,
+        YXDeviceState.SWEEP_AND_MOP,
+        YXDeviceState.PAUSED,
+        YXDeviceState.TRANSITIONING,
+    ],
+)
+def test_current_room_is_available_during_active_cleaning_states(status: YXDeviceState) -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    map_dps.update_from_dps({B01_Q10_DP.STATUS: status.code})
+    trait.update_from_map_packet(packet)
+    trait.update_from_trace_packet(trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        return_value=packet.rooms[0],
+    ) as resolve:
+        assert trait.current_room == packet.rooms[0]
+        resolve.assert_called_once_with(packet, trace)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        None,
+        YXDeviceState.UNKNOWN,
+        YXDeviceState.IDLE,
+        YXDeviceState.RETURNING_HOME,
+        YXDeviceState.RELOCATING,
+        YXDeviceState.CHARGING,
+        YXDeviceState.EMPTYING_THE_BIN,
+    ],
+)
+def test_current_room_is_unavailable_outside_active_cleaning(
+    status: YXDeviceState | None,
+) -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    if status is not None:
+        map_dps.update_from_dps({B01_Q10_DP.STATUS: status.code})
+    trait.update_from_map_packet(packet)
+    trait.update_from_trace_packet(parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes()))
+
+    with patch("roborock.devices.traits.b01.q10.map.resolve_q10_current_room") as resolve:
+        assert trait.current_room is None
+        resolve.assert_not_called()
+
+
+def test_current_room_handles_status_arriving_after_map_and_trace() -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    trait.update_from_map_packet(packet)
+    trait.update_from_trace_packet(trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        side_effect=lambda *_: replace(packet.rooms[0]),
+    ):
+        assert trait.current_room is None
+        map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+        assert trait.current_room == packet.rooms[0]
+
+
+def test_current_room_handles_map_arriving_after_status_and_trace() -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+    trait.update_from_trace_packet(trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        side_effect=lambda *_: replace(packet.rooms[0]),
+    ):
+        assert trait.current_room is None
+        trait.update_from_map_packet(packet)
+        assert trait.current_room == packet.rooms[0]
+
+
+@pytest.mark.parametrize(
+    "ending_status",
+    [YXDeviceState.UNKNOWN, YXDeviceState.IDLE, YXDeviceState.RETURNING_HOME],
+)
+def test_leaving_cleaning_clears_current_room_without_reusing_stale_trace(
+    ending_status: YXDeviceState,
+) -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+    trait.update_from_map_packet(packet)
+    trait.update_from_trace_packet(trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        side_effect=lambda *_: replace(packet.rooms[0]),
+    ) as resolve:
+        assert trait.current_room == packet.rooms[0]
+        map_dps.update_from_dps({B01_Q10_DP.STATUS: ending_status.code})
+        assert trait.current_room is None
+        assert trait.path == trace.points
+        assert resolve.call_count == 1
+
+
+def test_new_cleaning_session_waits_for_a_fresh_trace() -> None:
+    """A status-first new session cannot reuse the prior session's position."""
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    old_trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    new_trace = replace(old_trace, heading=old_trace.heading + 1)
+    map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+    trait.update_from_map_packet(packet)
+    trait.update_from_trace_packet(old_trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        side_effect=lambda *_: replace(packet.rooms[0]),
+    ) as resolve:
+        assert trait.current_room == packet.rooms[0]
+        map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.IDLE.code})
+        map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+        assert trait.current_room is None
+        trait.update_from_trace_packet(new_trace)
+        assert trait.current_room == packet.rooms[0]
+        assert resolve.call_count == 2
+
+
+def test_current_room_requires_both_map_and_trace() -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+
+    assert trait.current_room is None
+    trait.update_from_map_packet(parse_map_packet(FIXTURE.read_bytes()))
+    assert trait.current_room is None
+
+
+def test_current_room_is_a_defensive_copy_and_serializes_for_consumers() -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+    trait.update_from_map_packet(packet)
+    trait.update_from_trace_packet(trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        side_effect=lambda *_: replace(packet.rooms[0]),
+    ):
+        exposed = trait.current_room
+        assert exposed is not None
+        assert exposed is not packet.rooms[0]
+        exposed.raw_name = "mutated"
+        assert trait.current_room is not None
+        assert trait.current_room.raw_name == "rr_living_room"
+        assert trait.current_room.name == "Living Room"
+        assert trait.as_dict()["currentRoom"] == packet.rooms[0].as_dict()
+        assert "currentRoom" not in trait.as_dict({"currentRoom"})
+
+
+def test_current_room_serializes_none_when_unknown() -> None:
+    assert _map_trait().as_dict()["currentRoom"] is None
 
 
 def test_q10_position_is_available_as_top_level_cli_command() -> None:
@@ -252,7 +430,7 @@ async def test_subscribe_loop_routes_map_push(
     message_queue.put_nowait(parse_map_packet(FIXTURE.read_bytes()))
 
     await _wait_for(lambda: q10_api.map.image_content is not None)
-    assert {room.id: room.name for room in q10_api.map.rooms} == {2: "Living Room", 3: "Bedroom"}
+    assert {room.id: room.name for room in q10_api.map.rooms} == {2: "Living Room", 3: "bedroom"}
 
 
 async def test_archived_map_pushes_cannot_overwrite_live_map(
@@ -324,6 +502,27 @@ def test_saved_map_detail_exposes_obstacles(q10_api: Q10PropertiesApi) -> None:
     exposed = q10_api.maps.detail_obstacles
     exposed.clear()
     assert q10_api.maps.detail_obstacles == packet.obstacles
+
+
+def test_archived_map_details_do_not_expose_or_replace_current_room(q10_api: Q10PropertiesApi) -> None:
+    payload = FIXTURE.read_bytes()
+    current = parse_map_packet(payload)
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    q10_api._map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+    q10_api.map.update_from_map_packet(current)
+    q10_api.map.update_from_trace_packet(trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        return_value=current.rooms[0],
+    ):
+        assert q10_api.map.current_room == current.rooms[0]
+        q10_api._handle_message(parse_map_packet(b"\x03\x01" + payload[2:]))
+        q10_api._handle_message(parse_map_packet(b"\x04\x01" + payload[2:]))
+        assert q10_api.map.current_room == current.rooms[0]
+
+    assert not hasattr(q10_api.clean_history, "current_room")
+    assert not hasattr(q10_api.maps, "current_room")
 
 
 def test_all_q10_map_views_share_the_injected_render_config(
@@ -726,6 +925,28 @@ def test_docked_state_clears_stale_live_trace(render_map: Mock) -> None:
     assert trait.path == []
     assert render_map.call_args.args[1] is None
     assert render_map.call_args.kwargs["robot_at_dock"] is True
+
+
+def test_docked_state_clears_current_room_and_ignores_late_trace() -> None:
+    map_dps = MapDpsTrait()
+    trait = _map_trait(map_dps)
+    packet = parse_map_packet(FIXTURE.read_bytes())
+    trace = parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes())
+    map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CLEANING.code})
+    trait.update_from_map_packet(packet)
+    trait.update_from_trace_packet(trace)
+
+    with patch(
+        "roborock.devices.traits.b01.q10.map.resolve_q10_current_room",
+        return_value=packet.rooms[0],
+    ) as resolve:
+        assert trait.current_room == packet.rooms[0]
+        map_dps.update_from_dps({B01_Q10_DP.STATUS: YXDeviceState.CHARGING.code})
+        assert trait.current_room is None
+        trait.update_from_trace_packet(trace)
+        assert trait.current_room is None
+        assert trait.path == []
+        assert resolve.call_count == 1
 
 
 def test_late_trace_is_ignored_while_docked(render_map: Mock) -> None:

--- a/tests/map/test_b01_q10_map_parser.py
+++ b/tests/map/test_b01_q10_map_parser.py
@@ -155,7 +155,7 @@ def test_packet_layers_decompose_q10_fixture() -> None:
     """The Q10 synthetic fixture splits into floor + per-room layers."""
     layers = parse_map_packet(_payload()).layers
     assert layers.class_counts.get(LAYER_FLOOR) == 26
-    assert {room.id: room.name for room in layers.rooms} == {2: "Living Room", 3: "Bedroom"}
+    assert {room.id: room.name for room in layers.rooms} == {2: "Living Room", 3: "bedroom"}
 
     living = layers.render_room(2, (255, 0, 0, 255))
     image = Image.open(io.BytesIO(living))
@@ -235,9 +235,9 @@ def test_parse_map_packet_dimensions_straddling_256() -> None:
 
 
 def test_room_name_normalization() -> None:
-    """Firmware ``rr_`` default names are normalized; custom names are titled."""
+    """Firmware ``rr_`` defaults are normalized; custom names stay verbatim."""
     assert Q10Room(id=2, raw_name="rr_living_room", pixel_value=8, pixel_count=9).name == "Living Room"
-    assert Q10Room(id=3, raw_name="bedroom", pixel_value=12, pixel_count=9).name == "Bedroom"
+    assert Q10Room(id=3, raw_name="Owner’s bedroom", pixel_value=12, pixel_count=9).name == "Owner’s bedroom"
 
 
 def test_room_pixel_count_matches_grid() -> None:
@@ -252,7 +252,7 @@ def test_parser_renders_png_and_room_names() -> None:
     assert parsed.image_content is not None
     assert parsed.image_content[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic
     assert parsed.map_data is not None
-    assert parsed.map_data.additional_parameters["room_names"] == {2: "Living Room", 3: "Bedroom"}
+    assert parsed.map_data.additional_parameters["room_names"] == {2: "Living Room", 3: "bedroom"}
 
 
 def test_parse_packet_preserves_decoded_packet_api() -> None:

--- a/tests/map/test_b01_q10_map_parser.py
+++ b/tests/map/test_b01_q10_map_parser.py
@@ -2,6 +2,7 @@
 
 import io
 from pathlib import Path
+from typing import Any
 
 import pytest
 from PIL import Image
@@ -10,9 +11,14 @@ from roborock.exceptions import RoborockException
 from roborock.map.b01_grid_layers import LAYER_BACKGROUND, LAYER_FLOOR, LAYER_WALL
 from roborock.map.b01_q10_map_parser import (
     B01Q10MapParser,
+    Q10MapPacket,
+    Q10MapPacketKind,
+    Q10Point,
     Q10Room,
     classify_q10_cell,
+    is_clean_record_map_packet,
     is_map_packet,
+    is_saved_map_packet,
     is_trace_packet,
     lz4_block_decompress,
     parse_map_packet,
@@ -105,6 +111,13 @@ def test_lz4_block_back_reference() -> None:
     # seq2: final literals-only token (0 literals) ends the block per LZ4 spec.
     block = bytes([0x14, ord("A"), 0x01, 0x00, 0x00])
     assert lz4_block_decompress(block) == b"A" * 9
+
+
+def test_lz4_block_rejects_output_over_limit() -> None:
+    block = bytes([0x14, ord("A"), 0x01, 0x00, 0x00])
+
+    with pytest.raises(RoborockException, match="maximum output size"):
+        lz4_block_decompress(block, max_output_size=8)
 
 
 def test_is_map_packet() -> None:
@@ -356,10 +369,29 @@ def test_parse_trace_rejects_misaligned_points() -> None:
         parse_trace_packet(b"\x02\x01" + b"\x00" * 12 + b"\x01\x02\x03")
 
 
+@pytest.mark.parametrize("declared_count", [0, 2])
+def test_parse_trace_rejects_declared_count_mismatch(declared_count: int) -> None:
+    """An aligned body cannot silently disagree with the firmware count."""
+    payload = bytearray(_trace_payload([(10, 20)]))
+    payload[8:10] = declared_count.to_bytes(2, "big")
+
+    with pytest.raises(RoborockException, match="point count"):
+        parse_trace_packet(bytes(payload))
+
+
 def test_parse_rejects_bad_layout_length() -> None:
     payload = bytearray(_payload())
     payload[27:29] = (0xFFFF).to_bytes(2, "big")  # compressed length past the buffer
     with pytest.raises(RoborockException, match="invalid layout block length"):
+        parse_map_packet(bytes(payload))
+
+
+def test_parse_rejects_unreasonable_header_dimensions() -> None:
+    payload = bytearray(_payload())
+    payload[7:9] = (65535).to_bytes(2, "big")
+    payload[9:11] = (65535).to_bytes(2, "big")
+
+    with pytest.raises(RoborockException, match="supported grid size"):
         parse_map_packet(bytes(payload))
 
 
@@ -385,6 +417,32 @@ def _carpet_tail(width: int, height: int, carpet: bytes, erase: bytes = bytes([0
     """Build a packet tail: an erase section followed by a carpet-mask section."""
     block = _literal_lz4_block(carpet)
     return erase + (width * height).to_bytes(4, "big") + len(block).to_bytes(2, "big") + block
+
+
+def _map_detail_payload(
+    marker: bytes,
+    points: list[tuple[int, int]],
+    *,
+    version: int = 1,
+    opaque_value: int = 2,
+    heading: int = 3,
+    reserved: int = 0,
+    prefix: int = 0,
+    trailing: bytes = b"",
+) -> bytes:
+    """Build a neutral synthetic detail packet from the existing map fixture."""
+    header = (
+        version.to_bytes(2, "big")
+        + opaque_value.to_bytes(4, "big")
+        + len(points).to_bytes(4, "big")
+        + heading.to_bytes(2, "big", signed=True)
+        + reserved.to_bytes(2, "big")
+    )
+    point_table = b"".join(x.to_bytes(2, "big", signed=True) + y.to_bytes(2, "big", signed=True) for x, y in points)
+    history = bytes([prefix]) + header + point_table
+    payload = bytearray(FIXTURE.read_bytes() + _carpet_tail(8, 6, bytes(48)) + history + trailing)
+    payload[:2] = marker
+    return bytes(payload)
 
 
 def test_parse_carpet_mask_from_map_packet_tail() -> None:
@@ -413,6 +471,100 @@ def test_parse_carpet_mask_from_map_packet_tail() -> None:
 
 def test_parse_map_packet_without_carpet() -> None:
     assert parse_map_packet(FIXTURE.read_bytes()).carpet_mask is None
+
+
+def test_classify_current_clean_record_and_saved_map_packets() -> None:
+    """All known map markers retain an explicit semantic kind."""
+    current = FIXTURE.read_bytes()
+    clean_record = _map_detail_payload(b"\x03\x01", [(10, -20)])
+    saved_map = _map_detail_payload(b"\x04\x01", [(10, -20)])
+
+    assert is_map_packet(current)
+    assert is_clean_record_map_packet(clean_record)
+    assert is_saved_map_packet(saved_map)
+    assert parse_map_packet(current).kind is Q10MapPacketKind.CURRENT
+    assert parse_map_packet(clean_record).kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL
+    assert parse_map_packet(saved_map).kind is Q10MapPacketKind.SAVED_MAP_DETAIL
+
+
+def test_parse_clean_record_historical_trace_and_preserve_unknown_tail() -> None:
+    """The bounded historical path is decoded while later bytes stay opaque."""
+    packet = parse_map_packet(_map_detail_payload(b"\x03\x01", [(10, -20), (-30, 40)], trailing=b"future-section"))
+
+    assert packet.historical_trace is not None
+    assert [(point.x, point.y) for point in packet.historical_trace.points] == [(10, -20), (-30, 40)]
+    assert packet.historical_trace.version == 1
+    assert packet.historical_trace.opaque_value == 2
+    assert packet.historical_trace.heading == 3
+    assert packet.historical_trace.robot_position == Q10Point(-30, 40)
+    assert packet.trailing_bytes == b"future-section"
+
+
+def test_zero_point_historical_trace_preserves_following_section() -> None:
+    """A zero-point path leaves the following section byte-exact."""
+    packet = parse_map_packet(_map_detail_payload(b"\x03\x01", [], trailing=b"recorded-path"))
+
+    assert packet.historical_trace is not None
+    assert packet.historical_trace.points == []
+    assert packet.trailing_bytes == b"recorded-path"
+
+
+def test_historical_trace_is_not_inferred_for_other_packet_kinds() -> None:
+    """The validated ``03 01`` layout is not assumed for current or saved maps."""
+    current = parse_map_packet(_map_detail_payload(b"\x01\x01", [(10, -20)]))
+    saved_map = parse_map_packet(_map_detail_payload(b"\x04\x01", [(10, -20)]))
+
+    assert current.historical_trace is None
+    assert saved_map.historical_trace is None
+    assert current.trailing_bytes
+    assert saved_map.trailing_bytes
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"version": 2},
+        {"reserved": 1},
+        {"prefix": 1},
+    ],
+)
+def test_unsupported_historical_trace_header_remains_opaque(kwargs: dict[str, Any]) -> None:
+    payload = _map_detail_payload(b"\x03\x01", [(10, -20)], **kwargs)
+    packet = parse_map_packet(payload)
+
+    assert packet.historical_trace is None
+    assert packet.trailing_bytes.startswith(bytes([kwargs.get("prefix", 0)]))
+
+
+def test_truncated_historical_trace_remains_opaque() -> None:
+    payload = _map_detail_payload(b"\x03\x01", [(10, -20)])[:-2]
+    packet = parse_map_packet(payload)
+
+    assert packet.historical_trace is None
+    assert packet.trailing_bytes.startswith(b"\x00")
+
+
+def test_invalid_erase_section_is_preserved_opaque() -> None:
+    """An invalid erase header cannot become an anchor for later sections."""
+    tail = b"\x01\xffopaque-tail"
+    payload = bytearray(FIXTURE.read_bytes() + tail)
+    payload[:2] = b"\x03\x01"
+
+    packet = parse_map_packet(bytes(payload))
+
+    assert packet.erase_zones == []
+    assert packet.carpet_mask is None
+    assert packet.historical_trace is None
+    assert packet.trailing_bytes == tail
+
+
+def test_q10_map_packet_keeps_legacy_positional_field_order() -> None:
+    """New archive fields do not reinterpret existing positional arguments."""
+    room = Q10Room(id=1, raw_name="Room", pixel_value=8, pixel_count=1)
+    packet = Q10MapPacket(1, 1, 1, b"\x08", [room])
+
+    assert packet.rooms == [room]
+    assert packet.kind is Q10MapPacketKind.CURRENT
 
 
 def test_carpet_mask_ignored_when_uncompressed_len_mismatches() -> None:

--- a/tests/map/test_b01_q10_map_parser.py
+++ b/tests/map/test_b01_q10_map_parser.py
@@ -13,6 +13,7 @@ from roborock.map.b01_q10_map_parser import (
     B01Q10MapParser,
     Q10MapPacket,
     Q10MapPacketKind,
+    Q10Obstacle,
     Q10Point,
     Q10Room,
     classify_q10_cell,
@@ -423,24 +424,35 @@ def _map_detail_payload(
     marker: bytes,
     points: list[tuple[int, int]],
     *,
+    obstacles: list[tuple[int, int]] | None = None,
+    skip_cleaning_points: list[tuple[int, int]] | None = None,
     version: int = 1,
     opaque_value: int = 2,
     heading: int = 3,
     reserved: int = 0,
-    prefix: int = 0,
     trailing: bytes = b"",
 ) -> bytes:
     """Build a neutral synthetic detail packet from the existing map fixture."""
+    obstacle_points = obstacles or []
+    skipped_points = skip_cleaning_points or []
+    obstacle_table = bytes([len(obstacle_points)]) + b"".join(
+        x.to_bytes(2, "big", signed=True) + y.to_bytes(2, "big", signed=True) for x, y in obstacle_points
+    )
+    skip_table = bytes([len(skipped_points)]) + b"".join(
+        x.to_bytes(2, "big", signed=True) + y.to_bytes(2, "big", signed=True) for x, y in skipped_points
+    )
     header = (
-        version.to_bytes(2, "big")
+        version.to_bytes(1, "big")
         + opaque_value.to_bytes(4, "big")
         + len(points).to_bytes(4, "big")
         + heading.to_bytes(2, "big", signed=True)
         + reserved.to_bytes(2, "big")
     )
     point_table = b"".join(x.to_bytes(2, "big", signed=True) + y.to_bytes(2, "big", signed=True) for x, y in points)
-    history = bytes([prefix]) + header + point_table
-    payload = bytearray(FIXTURE.read_bytes() + _carpet_tail(8, 6, bytes(48)) + history + trailing)
+    history = header + point_table
+    payload = bytearray(
+        FIXTURE.read_bytes() + _carpet_tail(8, 6, bytes(48)) + obstacle_table + skip_table + history + trailing
+    )
     payload[:2] = marker
     return bytes(payload)
 
@@ -471,6 +483,70 @@ def test_parse_carpet_mask_from_map_packet_tail() -> None:
 
 def test_parse_map_packet_without_carpet() -> None:
     assert parse_map_packet(FIXTURE.read_bytes()).carpet_mask is None
+
+
+def test_parse_obstacles_and_skip_cleaning_points_before_historical_trace() -> None:
+    """Each post-carpet point table is bounded before the 03 path header."""
+    packet = parse_map_packet(
+        _map_detail_payload(
+            b"\x03\x01",
+            [(11, -12), (13, -14)],
+            obstacles=[(250, -300), (-32768, 32767)],
+            skip_cleaning_points=[(-40, 50)],
+        )
+    )
+
+    assert packet.obstacles == [Q10Obstacle(250, -300), Q10Obstacle(-32768, 32767)]
+    assert packet.skip_cleaning_points == [Q10Point(-40, 50)]
+    assert packet.historical_trace is not None
+    assert packet.historical_trace.points == [Q10Point(11, -12), Q10Point(13, -14)]
+    assert packet.trailing_bytes == b""
+
+
+@pytest.mark.parametrize("marker", [b"\x01\x01", b"\x04\x01"])
+def test_obstacles_are_decoded_for_current_and_saved_maps(marker: bytes) -> None:
+    """Obstacle metadata belongs to the map package, not only clean history."""
+    packet = parse_map_packet(
+        _map_detail_payload(
+            marker,
+            [],
+            obstacles=[(100, 200)],
+            skip_cleaning_points=[(30, -40)],
+        )
+    )
+
+    assert packet.obstacles == [Q10Obstacle(100, 200)]
+    assert packet.skip_cleaning_points == [Q10Point(30, -40)]
+    assert packet.historical_trace is None
+
+
+def test_empty_obstacle_sections_do_not_consume_historical_header() -> None:
+    packet = parse_map_packet(_map_detail_payload(b"\x03\x01", [(10, -20)]))
+
+    assert packet.obstacles == []
+    assert packet.skip_cleaning_points == []
+    assert packet.historical_trace is not None
+    assert packet.historical_trace.points == [Q10Point(10, -20)]
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        b"\x02\x00\x01\x00\x02",  # two obstacles declared, only one present
+        b"\x00\x02\x00\x01\x00\x02",  # two skip points declared, only one present
+    ],
+)
+def test_truncated_obstacle_sections_remain_opaque(section: bytes) -> None:
+    """A partial point table is never reinterpreted as a later section."""
+    payload = bytearray(FIXTURE.read_bytes() + _carpet_tail(8, 6, bytes(48)) + section)
+    payload[:2] = b"\x03\x01"
+
+    packet = parse_map_packet(bytes(payload))
+
+    assert packet.obstacles == []
+    assert packet.skip_cleaning_points == []
+    assert packet.historical_trace is None
+    assert packet.trailing_bytes == section
 
 
 def test_classify_current_clean_record_and_saved_map_packets() -> None:
@@ -525,7 +601,6 @@ def test_historical_trace_is_not_inferred_for_other_packet_kinds() -> None:
     [
         {"version": 2},
         {"reserved": 1},
-        {"prefix": 1},
     ],
 )
 def test_unsupported_historical_trace_header_remains_opaque(kwargs: dict[str, Any]) -> None:
@@ -533,7 +608,7 @@ def test_unsupported_historical_trace_header_remains_opaque(kwargs: dict[str, An
     packet = parse_map_packet(payload)
 
     assert packet.historical_trace is None
-    assert packet.trailing_bytes.startswith(bytes([kwargs.get("prefix", 0)]))
+    assert packet.trailing_bytes.startswith(bytes([kwargs.get("version", 1)]))
 
 
 def test_truncated_historical_trace_remains_opaque() -> None:
@@ -541,7 +616,7 @@ def test_truncated_historical_trace_remains_opaque() -> None:
     packet = parse_map_packet(payload)
 
     assert packet.historical_trace is None
-    assert packet.trailing_bytes.startswith(b"\x00")
+    assert packet.trailing_bytes.startswith(b"\x01")
 
 
 def test_invalid_erase_section_is_preserved_opaque() -> None:

--- a/tests/map/test_b01_q10_overlays.py
+++ b/tests/map/test_b01_q10_overlays.py
@@ -2,11 +2,14 @@
 
 import base64
 
+import pytest
+
 from roborock.map.b01_q10_overlays import (
     ZONE_TYPE_NO_GO,
     ZONE_TYPE_NO_MOP,
     ZONE_TYPE_THRESHOLD,
     ZONE_TYPE_VIRTUAL_WALL,
+    is_replaceable_zone_blob,
     parse_virtual_wall_blob,
     parse_zone_blob,
 )
@@ -59,7 +62,24 @@ def test_parse_zone_blob_accepts_base64() -> None:
 def test_parse_zone_blob_empty_variants() -> None:
     assert parse_zone_blob(None) == []
     assert parse_zone_blob("AA==") == []  # base64 of 0x00
+    assert parse_zone_blob("AQA=") == []  # version=1, count=0
     assert parse_zone_blob("AQAA") == []  # version=1, count=0
+
+
+@pytest.mark.parametrize(
+    "blob",
+    ["AQA=", "AQAA", _encoded(_blob(1, [_rect(0, [(0, 0), (1, 0), (1, 1), (0, 1)])]))],
+)
+def test_replaceable_zone_blob_accepts_supported_snapshots(blob: str) -> None:
+    assert is_replaceable_zone_blob(blob)
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [None, "not-base64", "AQE=", _encoded(_blob(1, [_rect(0, [(0, 0)] * 5)]))],
+)
+def test_replaceable_zone_blob_rejects_missing_or_unsupported_snapshots(blob: str | None) -> None:
+    assert not is_replaceable_zone_blob(blob)
 
 
 def test_parse_zone_blob_skips_malformed_record() -> None:

--- a/tests/map/test_b01_q10_render.py
+++ b/tests/map/test_b01_q10_render.py
@@ -18,6 +18,7 @@ from roborock.map.b01_q10_map_parser import (
     B01Q10MapParserConfig,
     Q10EraseZone,
     Q10HeaderCalibration,
+    Q10HistoricalTracePacket,
     Q10MapPacket,
     Q10Point,
     Q10TracePacket,
@@ -58,7 +59,7 @@ def _packet() -> Q10MapPacket:
 def _render(
     packet: Q10MapPacket | None = None,
     *,
-    trace: Q10TracePacket | None = None,
+    trace: Q10TracePacket | Q10HistoricalTracePacket | None = None,
     overlays: Q10MapOverlays | None = None,
 ) -> bytes:
     return render_q10_map(
@@ -115,6 +116,14 @@ def test_render_draws_path_and_position() -> None:
     assert rendered.size == (8 * 4, 6 * 4)
     # The shared V1 robot glyph has a white body at its center.
     assert rendered.getpixel(image_position) == (255, 255, 255, 255)
+
+
+def test_render_accepts_historical_trace() -> None:
+    """A validated clean-record path uses the same calibrated drawing path."""
+    packet, live_trace = _calibrated_inputs()
+    historical = Q10HistoricalTracePacket(points=live_trace.points, heading=live_trace.heading)
+
+    assert _render(packet, trace=historical) == _render(packet, trace=live_trace)
 
 
 def test_render_draws_zones_and_virtual_walls() -> None:

--- a/tests/map/test_b01_q10_render.py
+++ b/tests/map/test_b01_q10_render.py
@@ -225,6 +225,14 @@ def test_render_applies_erase_zones_from_header_without_trace() -> None:
     assert render != base
 
 
+def test_header_vector_calibration_is_independent_of_trace_orientation() -> None:
+    """A live trace cannot flip saved erase/restriction geometry vertically."""
+    packet = replace(_packet(), header_calibration=HEADER)
+    mirrored_trace = replace(TRACE_CALIBRATION, y_sign=-1)
+
+    assert _vector_calibration(packet, mirrored_trace) == VECTOR_CALIBRATION
+
+
 def test_render_partial_erase() -> None:
     """An erase rectangle only blanks the cells it covers, leaving the rest."""
     packet, trace = _calibrated_inputs()

--- a/tests/map/test_b01_q10_render.py
+++ b/tests/map/test_b01_q10_render.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from PIL import Image
+from vacuum_map_parser_base.config.drawable import Drawable
 from vacuum_map_parser_base.config.size import Size, Sizes
 from vacuum_map_parser_base.map_data import MapData, Point
 
@@ -20,6 +21,7 @@ from roborock.map.b01_q10_map_parser import (
     Q10HeaderCalibration,
     Q10HistoricalTracePacket,
     Q10MapPacket,
+    Q10Obstacle,
     Q10Point,
     Q10TracePacket,
     parse_map_packet,
@@ -35,7 +37,9 @@ from roborock.map.b01_q10_render import (
     Q10MapOverlays,
     _calibration_from_header_metadata,
     _erased_cells,
+    _obstacle_calibration,
     _place_docked_robot,
+    _place_obstacles,
     _vector_calibration,
     render_q10_map,
     solve_q10_calibration,
@@ -124,6 +128,63 @@ def test_render_accepts_historical_trace() -> None:
     historical = Q10HistoricalTracePacket(points=live_trace.points, heading=live_trace.heading)
 
     assert _render(packet, trace=historical) == _render(packet, trace=live_trace)
+
+
+def test_place_obstacles_uses_its_validated_coordinate_scale() -> None:
+    """Obstacle coordinates use 50 raw units per grid pixel around the origin."""
+    packet = replace(
+        _packet(),
+        header_calibration=replace(HEADER, charger_x=0, charger_y=0),
+        obstacles=[Q10Obstacle(50, 100), Q10Obstacle(-50, -50)],
+    )
+    map_data = MapData()
+
+    calibration = _obstacle_calibration(packet)
+    assert calibration == GridCalibration(resolution=50.0, origin_x=0.0, origin_y=5.0, y_sign=1)
+    assert _place_obstacles(map_data, packet)
+    assert map_data.obstacles is not None
+    assert [(obstacle.x, obstacle.y) for obstacle in map_data.obstacles] == [(1.0, 3.0), (-1.0, 6.0)]
+    assert all(obstacle.details.type is None for obstacle in map_data.obstacles)
+
+
+def test_place_obstacles_requires_header_calibration() -> None:
+    """Unanchored obstacle points remain exposed but cannot be drawn safely."""
+    packet = replace(_packet(), header_calibration=None, obstacles=[Q10Obstacle(50, 100)])
+    map_data = MapData()
+
+    assert _obstacle_calibration(packet) is None
+    assert not _place_obstacles(map_data, packet)
+    assert map_data.obstacles is None
+
+
+def test_render_obstacles_respects_drawables_config() -> None:
+    packet = replace(
+        _packet(),
+        header_calibration=replace(HEADER, charger_x=0, charger_y=0),
+        obstacles=[Q10Obstacle(100, 100)],
+    )
+
+    hidden = render_q10_map(packet, None, Q10MapOverlays(), config=B01Q10MapParserConfig(drawables=[]))
+    visible = render_q10_map(
+        packet,
+        None,
+        Q10MapOverlays(),
+        config=B01Q10MapParserConfig(drawables=[Drawable.OBSTACLES]),
+    )
+
+    assert visible != hidden
+
+
+def test_skip_cleaning_points_are_not_rendered_as_obstacles() -> None:
+    """The distinct skip-clean table must never gain an obstacle glyph."""
+    packet = replace(
+        _packet(),
+        header_calibration=replace(HEADER, charger_x=0, charger_y=0),
+        skip_cleaning_points=[Q10Point(100, 100)],
+    )
+    config = B01Q10MapParserConfig(drawables=[Drawable.OBSTACLES])
+
+    assert _render(packet) == render_q10_map(packet, None, Q10MapOverlays(), config=config)
 
 
 def test_render_draws_zones_and_virtual_walls() -> None:

--- a/tests/map/test_b01_q10_render.py
+++ b/tests/map/test_b01_q10_render.py
@@ -8,7 +8,10 @@ trait's own tests cover the state management that drives this module.
 import io
 from dataclasses import replace
 from pathlib import Path
+from typing import cast
+from unittest.mock import patch
 
+import pytest
 from PIL import Image
 from vacuum_map_parser_base.config.drawable import Drawable
 from vacuum_map_parser_base.config.size import Size, Sizes
@@ -23,6 +26,7 @@ from roborock.map.b01_q10_map_parser import (
     Q10MapPacket,
     Q10Obstacle,
     Q10Point,
+    Q10Room,
     Q10TracePacket,
     parse_map_packet,
 )
@@ -33,15 +37,16 @@ from roborock.map.b01_q10_overlays import (
     Q10Zone,
 )
 from roborock.map.b01_q10_render import (
-    _Q10_RESOLUTIONS,
     Q10MapOverlays,
     _calibration_from_header_metadata,
     _erased_cells,
     _obstacle_calibration,
     _place_docked_robot,
     _place_obstacles,
+    _room_at_position,
     _vector_calibration,
     render_q10_map,
+    resolve_q10_current_room,
     solve_q10_calibration,
 )
 
@@ -91,6 +96,20 @@ def _world_vertices(calibration: GridCalibration, pixels: list[tuple[int, int]])
         world_x, world_y = calibration.pixel_to_world(px, py)
         vertices.append((int(world_x), int(world_y)))
     return vertices
+
+
+def _room_packet(grid: list[int], width: int) -> Q10MapPacket:
+    """Build a minimal segmented map for deterministic room lookup tests."""
+    return Q10MapPacket(
+        map_id=1,
+        width=width,
+        height=len(grid) // width,
+        grid=bytes(grid),
+        rooms=[
+            Q10Room(2, "rr_kitchen", 8, grid.count(8)),
+            Q10Room(3, "hall", 12, grid.count(12)),
+        ],
+    )
 
 
 def _calibrated_inputs(*, heading: int = 0) -> tuple[Q10MapPacket, Q10TracePacket]:
@@ -187,6 +206,126 @@ def test_skip_cleaning_points_are_not_rendered_as_obstacles() -> None:
     assert _render(packet) == render_q10_map(packet, None, Q10MapOverlays(), config=config)
 
 
+def test_room_at_position_exact_segment_wins_over_nearby_majority() -> None:
+    packet = _room_packet([12, 12, 12, 12, 8, 12, 12, 12, 12], width=3)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    assert _room_at_position(packet, Q10Point(10, 10), calibration) == packet.rooms[0]
+
+
+def test_room_at_position_uses_half_open_cell_boundaries() -> None:
+    packet = _room_packet([8, 8, 12, 12], width=4)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    assert _room_at_position(packet, Q10Point(19, 0), calibration) == packet.rooms[0]
+    assert _room_at_position(packet, Q10Point(20, 0), calibration) == packet.rooms[1]
+
+
+@pytest.mark.parametrize("position", [Q10Point(-1, 10), Q10Point(30, 10), Q10Point(10, -1), Q10Point(10, 30)])
+def test_room_at_position_rejects_fractional_and_exact_out_of_bounds(position: Q10Point) -> None:
+    packet = _room_packet([8] * 9, width=3)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    assert _room_at_position(packet, position, calibration) is None
+
+
+@pytest.mark.parametrize("coordinate", [float("nan"), float("inf"), float("-inf")])
+def test_room_at_position_rejects_nonfinite_coordinates(coordinate: float) -> None:
+    packet = _room_packet([8], width=1)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    assert _room_at_position(packet, Q10Point(cast(int, coordinate), 0), calibration) is None
+
+
+def test_room_at_position_recovers_unique_nearby_room() -> None:
+    packet = _room_packet([8, 8, 8, 8, 0, 8, 8, 8, 8], width=3)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    assert _room_at_position(packet, Q10Point(10, 10), calibration) == packet.rooms[0]
+
+
+def test_room_at_position_expands_when_first_radius_has_no_room_cells() -> None:
+    grid = [8, 0, 0, 0, 8] + [0] * 15 + [8, 0, 0, 0, 8]
+    packet = _room_packet(grid, width=5)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    # Radius one has no segmented cells; radius two has only Kitchen cells.
+    assert _room_at_position(packet, Q10Point(20, 20), calibration) == packet.rooms[0]
+
+
+def test_room_at_position_returns_none_for_any_nearby_room_conflict() -> None:
+    packet = _room_packet([8, 0, 12, 8, 0, 8, 8, 8, 8], width=3)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    # Kitchen has the numerical majority, but Hall is also present in the first
+    # nonempty radius, so assigning a room would be ambiguous.
+    assert _room_at_position(packet, Q10Point(10, 10), calibration) is None
+
+
+def test_room_at_position_can_disable_nearby_fallback() -> None:
+    packet = _room_packet([8, 8, 8, 8, 0, 8, 8, 8, 8], width=3)
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    assert _room_at_position(packet, Q10Point(10, 10), calibration, search_radius=0) is None
+
+
+def test_room_at_position_requires_matching_room_metadata() -> None:
+    packet = replace(_room_packet([8], width=1), rooms=[])
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    assert _room_at_position(packet, Q10Point(0, 0), calibration) is None
+
+
+def test_resolve_current_room_uses_latest_live_position() -> None:
+    packet = _room_packet([8, 12], width=2)
+    trace = Q10TracePacket(points=[Q10Point(0, 0), Q10Point(10, 0)])
+    calibration = GridCalibration(resolution=10, origin_x=0, origin_y=0, y_sign=-1)
+
+    with patch("roborock.map.b01_q10_render.solve_q10_calibration", return_value=calibration):
+        room = resolve_q10_current_room(packet, trace)
+
+    assert room == packet.rooms[1]
+    assert room is not packet.rooms[1]
+    assert room is not None
+    room.raw_name = "mutated"
+    assert packet.rooms[1].raw_name == "hall"
+
+
+def test_resolve_current_room_requires_position_and_calibration() -> None:
+    packet = _room_packet([8], width=1)
+
+    assert resolve_q10_current_room(packet, None) is None
+    assert resolve_q10_current_room(packet, Q10TracePacket()) is None
+    assert resolve_q10_current_room(packet, Q10TracePacket(points=[Q10Point(0, 0)])) is None
+
+
+def test_single_point_uses_exact_header_transform_for_room_and_rendering() -> None:
+    packet = replace(
+        _packet(),
+        header_calibration=replace(HEADER, charger_x=0, charger_y=0),
+    )
+    trace = Q10TracePacket(points=[Q10Point(100, 60)], heading=45)
+
+    calibration = solve_q10_calibration(packet, trace)
+    assert calibration == TRACE_CALIBRATION
+    assert calibration.world_to_pixel(100, 60) == (5.0, 2.0)
+    assert resolve_q10_current_room(packet, trace) == packet.rooms[1]
+
+    rendered = Image.open(io.BytesIO(_render(packet, trace=trace))).convert("RGBA")
+    position = (5 * CONFIG.map_scale, 2 * CONFIG.map_scale)
+    assert rendered.getpixel(position) == (255, 255, 255, 255)
+
+
+def test_empty_trace_does_not_force_a_map_redraw() -> None:
+    """A metadata-only zero-point trace contributes no drawable content."""
+    packet = replace(
+        _packet(),
+        header_calibration=replace(HEADER, charger_x=0, charger_y=0),
+    )
+
+    assert _render(packet, trace=Q10TracePacket()) == _render(packet)
+
+
 def test_render_draws_zones_and_virtual_walls() -> None:
     """Decoded DPS overlays are included in the composed image."""
     packet, trace = _calibrated_inputs()
@@ -264,7 +403,9 @@ def test_zero_degree_dock_places_robot_to_its_right() -> None:
 def test_render_applies_erase_zones() -> None:
     """With a calibration, erase-zone cells are blanked from the image."""
     packet, trace = _calibrated_inputs()
-    base = _render(packet, trace=trace)
+    assert packet.header_calibration is not None
+    packet = replace(packet, header_calibration=replace(packet.header_calibration, charger_x=0, charger_y=0))
+    base = _render(packet)
     trace_calibration = solve_q10_calibration(packet, trace)
     calibration = _vector_calibration(packet, trace_calibration)
     assert calibration == VECTOR_CALIBRATION
@@ -273,7 +414,7 @@ def test_render_applies_erase_zones() -> None:
     corners = [(-1, -1), (8, -1), (8, 6), (-1, 6)]
     erase_zone = Q10EraseZone(vertices=_world_vertices(calibration, corners))
     cells = _erased_cells(packet.layers, [erase_zone], calibration)
-    render = _render(replace(packet, erase_zones=[erase_zone]), trace=trace)
+    render = _render(replace(packet, erase_zones=[erase_zone]))
 
     assert len(cells) == packet.layers.width * packet.layers.height
     assert render != base
@@ -306,7 +447,9 @@ def test_header_vector_calibration_is_independent_of_trace_orientation() -> None
 def test_render_partial_erase() -> None:
     """An erase rectangle only blanks the cells it covers, leaving the rest."""
     packet, trace = _calibrated_inputs()
-    base = _render(packet, trace=trace)
+    assert packet.header_calibration is not None
+    packet = replace(packet, header_calibration=replace(packet.header_calibration, charger_x=0, charger_y=0))
+    base = _render(packet)
     trace_calibration = solve_q10_calibration(packet, trace)
     calibration = _vector_calibration(packet, trace_calibration)
     assert calibration == VECTOR_CALIBRATION
@@ -315,7 +458,7 @@ def test_render_partial_erase() -> None:
     corners = [(-1, -1), (8, -1), (8, 2), (-1, 2)]
     erase_zone = Q10EraseZone(vertices=_world_vertices(calibration, corners))
     cells = _erased_cells(packet.layers, [erase_zone], calibration)
-    render = _render(replace(packet, erase_zones=[erase_zone]), trace=trace)
+    render = _render(replace(packet, erase_zones=[erase_zone]))
 
     assert 0 < len(cells) < packet.layers.width * packet.layers.height
     assert render != base
@@ -330,16 +473,34 @@ def test_render_robot_marker_reflects_heading() -> None:
 
 
 def test_solve_q10_calibration_uses_header_origin_with_short_path() -> None:
-    """A grid-frame header origin lets a short path calibrate (origin is exact)."""
+    """Validated header metadata calibrates a short path exactly."""
     packet, trace = _calibrated_inputs()
     assert len(trace.points) < 20  # far too short for the full origin+resolution fit
 
     cal = solve_q10_calibration(packet, trace)
     assert cal is not None
-    # Origin comes straight from the header (exact); only the resolution is fit,
-    # so it lands on one of the candidates (the exact pick is grid-quantized).
-    assert (cal.origin_x, cal.origin_y) == (0.0, 5.0)
-    assert cal.resolution in _Q10_RESOLUTIONS
+    assert cal == TRACE_CALIBRATION
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        replace(HEADER, resolution=100),
+        replace(HEADER, origin_x=100_000, origin_y=100_000),
+    ],
+)
+def test_solve_q10_calibration_rejects_implausible_header_and_falls_back(
+    header: Q10HeaderCalibration,
+) -> None:
+    """Corrupt metadata cannot displace an otherwise fit-able cleaning path."""
+    packet = replace(_packet(), header_calibration=header)
+    trace = Q10TracePacket(points=[Q10Point(index, index) for index in range(20)])
+    fallback = GridCalibration(resolution=17, origin_x=3, origin_y=4, y_sign=-1)
+
+    with patch("roborock.map.b01_q10_render._calibration_from_fit", return_value=fallback) as fit:
+        assert solve_q10_calibration(packet, trace) == fallback
+
+    fit.assert_called_once_with(packet.layers, [(point.x, point.y) for point in trace.points])
 
 
 def test_solve_q10_calibration_short_path_without_header_returns_none() -> None:

--- a/tests/protocols/test_b01_q10_protocol.py
+++ b/tests/protocols/test_b01_q10_protocol.py
@@ -13,7 +13,7 @@ from syrupy import SnapshotAssertion
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXWaterLevel
 from roborock.data.code_mappings import completed_warnings
 from roborock.exceptions import RoborockException
-from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10TracePacket
+from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10MapPacketKind, Q10TracePacket
 from roborock.protocols.b01_q10_protocol import (
     Q10DpsUpdate,
     decode_message,
@@ -67,6 +67,22 @@ def test_decode_message_map_packet() -> None:
     decoded = decode_message(message)
     assert isinstance(decoded, Q10MapPacket)
     assert {room.id: room.name for room in decoded.rooms} == {2: "Living Room", 3: "Bedroom"}
+
+
+@pytest.mark.parametrize(
+    ("marker", "kind"),
+    [
+        (b"\x03\x01", Q10MapPacketKind.CLEAN_RECORD_DETAIL),
+        (b"\x04\x01", Q10MapPacketKind.SAVED_MAP_DETAIL),
+    ],
+)
+def test_decode_message_archived_map_packet(marker: bytes, kind: Q10MapPacketKind) -> None:
+    """The decoder recognizes both archived map-detail markers."""
+    fixture = MAP_FIXTURE.read_bytes()
+    decoded = decode_message(_message(marker + fixture[2:], RoborockMessageProtocol.MAP_RESPONSE))
+
+    assert isinstance(decoded, Q10MapPacket)
+    assert decoded.kind is kind
 
 
 def test_decode_message_trace_packet() -> None:

--- a/tests/protocols/test_b01_q10_protocol.py
+++ b/tests/protocols/test_b01_q10_protocol.py
@@ -1,5 +1,6 @@
 """Tests for the B01 protocol message encoding and decoding."""
 
+import base64
 import json
 import logging
 import pathlib
@@ -11,14 +12,19 @@ from freezegun import freeze_time
 from syrupy import SnapshotAssertion
 
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXWaterLevel
+from roborock.data.b01_q10.b01_q10_containers import Q10RoborockPoint
 from roborock.data.code_mappings import completed_warnings
 from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10MapPacketKind, Q10TracePacket
+from roborock.map.b01_q10_overlays import Q10RestrictedZone, Q10RestrictionType, Q10VirtualWall
 from roborock.protocols.b01_q10_protocol import (
     Q10DpsUpdate,
     decode_message,
     decode_rpc_response,
     encode_mqtt_payload,
+    encode_restricted_zones,
+    encode_room_name,
+    encode_virtual_walls,
 )
 from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 
@@ -28,6 +34,211 @@ TESTDATA_IDS = [x.stem for x in TESTDATA_FILES]
 
 MAP_FIXTURE = pathlib.Path("tests/map/testdata/b01_q10_map.bin")
 TRACE_FIXTURE = pathlib.Path("tests/map/testdata/b01_q10_trace.bin")
+
+
+def _point(x: int, y: int) -> Q10RoborockPoint:
+    """Build a public-coordinate point from a captured Q10 wire vector."""
+    return Q10RoborockPoint.from_vector(x, y)
+
+
+def _zone(zone_type: Q10RestrictionType, *vertices: tuple[int, int]) -> Q10RestrictedZone:
+    return Q10RestrictedZone(zone_type, tuple(_point(*vertex) for vertex in vertices))  # type: ignore[arg-type]
+
+
+def _wall(start: tuple[int, int], end: tuple[int, int]) -> Q10VirtualWall:
+    return Q10VirtualWall(_point(*start), _point(*end))
+
+
+def test_encode_restricted_zones_real_three_zone_capture_byte_exact() -> None:
+    """Encoding is the exact inverse of a real three-zone DP 55 capture."""
+    captured = (
+        "AQMABP9A9ToAEPU6ABDzzv9A884AAAAAAAAAAAAAAAAAAAAAAAAAAAAE/Rb/mv5z/5r+c/3L/Rb9ywAAAA"
+        "AAAAAAAAAAAAAAAAAAAAAAAAQDpADEB3UAxAd1/GMDpPxjAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    )
+    zones = [
+        _zone(Q10RestrictionType.NO_GO, (-192, -2758), (16, -2758), (16, -3122), (-192, -3122)),
+        _zone(Q10RestrictionType.NO_GO, (-746, -102), (-397, -102), (-397, -565), (-746, -565)),
+        _zone(Q10RestrictionType.NO_GO, (932, 196), (1909, 196), (1909, -925), (932, -925)),
+    ]
+
+    assert encode_restricted_zones(zones) == captured
+
+
+def test_encode_restricted_zones_empty_is_device_canonical_payload() -> None:
+    assert encode_restricted_zones([]) == "AQA="
+
+
+def test_encode_restricted_zones_mixed_types_and_padding_byte_exact() -> None:
+    """Multiple restriction kinds retain order and fixed 38-byte padding."""
+    zones = [
+        _zone(Q10RestrictionType.NO_MOP, (-1, 2), (3, 4), (5, 6), (7, 8)),
+        _zone(Q10RestrictionType.THRESHOLD, (-32_768, 32_767), (0, 1), (2, 3), (4, 5)),
+    ]
+    record_one = bytes.fromhex("0204ffff0002000300040005000600070008") + bytes(20)
+    record_two = bytes.fromhex("030480007fff000000010002000300040005") + bytes(20)
+
+    assert base64.b64decode(encode_restricted_zones(zones)) == b"\x01\x02" + record_one + record_two
+
+
+def test_encode_virtual_walls_real_mixed_capture_byte_exact() -> None:
+    """Encoding preserves the proven x/y order for real horizontal and vertical walls."""
+    captured = "AgNyBGMFsARjAf8FAAH7CnE="
+    walls = [_wall((882, 1123), (1456, 1123)), _wall((511, 1280), (507, 2673))]
+
+    assert encode_virtual_walls(walls) == captured
+
+
+def test_encode_virtual_walls_empty_is_device_canonical_payload() -> None:
+    assert encode_virtual_walls([]) == "AA=="
+
+
+def test_encode_virtual_walls_signed_boundaries_byte_exact() -> None:
+    walls = [_wall((-32_768, 32_767), (32_767, -32_768))]
+
+    assert base64.b64decode(encode_virtual_walls(walls)) == bytes.fromhex("0180007fff7fff8000")
+
+
+@pytest.mark.parametrize("collection", ["not-zones", b"not-zones", [object()]])
+def test_encode_restricted_zones_rejects_wrong_collection_values(collection: Any) -> None:
+    with pytest.raises(ValueError, match="zones"):
+        encode_restricted_zones(collection)
+
+
+def test_encode_restricted_zones_rejects_more_than_wire_count() -> None:
+    zone = _zone(Q10RestrictionType.NO_GO, (0, 0), (1, 0), (1, 1), (0, 1))
+
+    with pytest.raises(ValueError, match="at most 255"):
+        encode_restricted_zones([zone] * 256)
+
+
+def test_encode_restricted_zones_rejects_wrong_type() -> None:
+    zone = Q10RestrictedZone(
+        "no-go",  # type: ignore[arg-type]
+        (_point(0, 0), _point(1, 0), _point(1, 1), _point(0, 1)),
+    )
+
+    with pytest.raises(ValueError, match="restricted-zone type"):
+        encode_restricted_zones([zone])
+
+
+def test_encode_restricted_zones_preserves_unknown_wire_type() -> None:
+    zone = Q10RestrictedZone(42, (_point(0, 0), _point(1, 0), _point(1, 1), _point(0, 1)))
+
+    assert base64.b64decode(encode_restricted_zones([zone]))[2] == 42
+
+
+@pytest.mark.parametrize(
+    "vertices",
+    [
+        ((0, 0), (1, 0), (1, 1)),
+        ((0, 0), (1, 0), (1, 1), (0, 1), (-1, 0)),
+    ],
+)
+def test_encode_restricted_zones_rejects_wrong_cardinality(vertices: tuple[tuple[int, int], ...]) -> None:
+    zone = Q10RestrictedZone(
+        Q10RestrictionType.NO_GO,
+        tuple(_point(*vertex) for vertex in vertices),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match="exactly four"):
+        encode_restricted_zones([zone])
+
+
+def test_encode_restricted_zones_rejects_duplicate_vertices() -> None:
+    duplicate = _point(0, 0)
+    zone = Q10RestrictedZone(
+        Q10RestrictionType.NO_GO,
+        (duplicate, _point(1, 0), _point(1, 1), duplicate),
+    )
+
+    with pytest.raises(ValueError, match="distinct"):
+        encode_restricted_zones([zone])
+
+
+@pytest.mark.parametrize(
+    ("vertices", "message"),
+    [
+        (((0, 0), (1, 0), (2, 0), (3, 0)), "enclose an area"),
+        (((0, 0), (2, 2), (0, 2), (2, 0)), "enclose an area|must not cross"),
+    ],
+)
+def test_encode_restricted_zones_rejects_invalid_geometry(
+    vertices: tuple[tuple[int, int], ...],
+    message: str,
+) -> None:
+    zone = _zone(Q10RestrictionType.NO_GO, *vertices)
+
+    with pytest.raises(ValueError, match=message):
+        encode_restricted_zones([zone])
+
+
+@pytest.mark.parametrize("collection", ["not-walls", b"not-walls", [object()]])
+def test_encode_virtual_walls_rejects_wrong_collection_values(collection: Any) -> None:
+    with pytest.raises(ValueError, match="walls"):
+        encode_virtual_walls(collection)
+
+
+def test_encode_virtual_walls_rejects_more_than_wire_count() -> None:
+    wall = _wall((0, 0), (1, 1))
+
+    with pytest.raises(ValueError, match="at most 255"):
+        encode_virtual_walls([wall] * 256)
+
+
+def test_encode_virtual_walls_rejects_duplicate_endpoints() -> None:
+    point = _point(0, 0)
+
+    with pytest.raises(ValueError, match="distinct"):
+        encode_virtual_walls([Q10VirtualWall(point, point)])
+
+
+@pytest.mark.parametrize(
+    "point",
+    [
+        Q10RoborockPoint(True, 25_500),
+        Q10RoborockPoint(25_500.0, 25_500),  # type: ignore[arg-type]
+        Q10RoborockPoint(25_501, 25_500),
+        Q10RoborockPoint(-138_345, 25_500),
+    ],
+)
+def test_zone_and_wall_encoders_reject_invalid_coordinates(point: Q10RoborockPoint) -> None:
+    valid = (_point(10, 10), _point(11, 10), _point(11, 11))
+    zone = Q10RestrictedZone(Q10RestrictionType.NO_GO, (point, *valid))
+    wall = Q10VirtualWall(point, _point(2, 2))
+
+    with pytest.raises(ValueError, match="coordinates"):
+        encode_restricted_zones([zone])
+    with pytest.raises(ValueError, match="coordinates"):
+        encode_virtual_walls([wall])
+
+
+def test_overlay_encoders_do_not_mutate_callers() -> None:
+    zones = [_zone(Q10RestrictionType.NO_MOP, (0, 0), (2, 0), (2, 2), (0, 2))]
+    walls = [_wall((-1, -1), (1, 1))]
+    original_zones = list(zones)
+    original_walls = list(walls)
+
+    encode_restricted_zones(zones)
+    encode_virtual_walls(walls)
+
+    assert zones == original_zones
+    assert walls == original_walls
+
+
+def test_encode_room_name_uses_fixed_utf8_field() -> None:
+    assert base64.b64decode(encode_room_name(7, "Café")) == bytes((1, 7, 0, 5)) + "Café".encode() + bytes(14)
+
+
+@pytest.mark.parametrize("room_id", [True, -1, 256, 1.0, "1"])
+def test_encode_room_name_rejects_invalid_room_id(room_id: Any) -> None:
+    with pytest.raises(ValueError, match="room_id"):
+        encode_room_name(room_id, "Study")
+
+
+@pytest.mark.parametrize("name", ["", "a\x00b", "x" * 20, "é" * 10, 1])
+def test_encode_room_name_rejects_invalid_name(name: Any) -> None:
+    with pytest.raises(ValueError, match="name"):
+        encode_room_name(7, name)
 
 
 def _message(payload: bytes, protocol: RoborockMessageProtocol) -> RoborockMessage:

--- a/tests/protocols/test_b01_q10_protocol.py
+++ b/tests/protocols/test_b01_q10_protocol.py
@@ -66,7 +66,7 @@ def test_decode_message_map_packet() -> None:
     message = _message(MAP_FIXTURE.read_bytes(), RoborockMessageProtocol.MAP_RESPONSE)
     decoded = decode_message(message)
     assert isinstance(decoded, Q10MapPacket)
-    assert {room.id: room.name for room in decoded.rooms} == {2: "Living Room", 3: "Bedroom"}
+    assert {room.id: room.name for room in decoded.rooms} == {2: "Living Room", 3: "bedroom"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from roborock.diagnostics import Diagnostics, redact_device_uid, redact_topic_name
+from roborock.diagnostics import REDACTED, Diagnostics, redact_device_data, redact_device_uid, redact_topic_name
 
 
 def test_empty_diagnostics():
@@ -10,6 +10,23 @@ def test_empty_diagnostics():
 
     diag = Diagnostics()
     assert diag.as_dict() == {}
+
+
+def test_redact_q10_raw_room_name() -> None:
+    """Custom Q10 room labels are private in exported diagnostics."""
+    assert redact_device_data(
+        {
+            "map": {
+                "rooms": [{"rawName": "Owner’s bedroom"}],
+                "currentRoom": {"rawName": "Owner’s bedroom"},
+            }
+        }
+    ) == {
+        "map": {
+            "rooms": [{"rawName": REDACTED}],
+            "currentRoom": {"rawName": REDACTED},
+        }
+    }
 
 
 def test_increment_counter():


### PR DESCRIPTION
> [!IMPORTANT]
> Updated against current upstream, preserving its Q10 position/zone/goto APIs and 30-second map-push timeout. This remains the older cumulative map-control branch; the focused archive stack (#936 → #937 → #938 → #939) and subsequent repartitioning still apply. This branch also includes the separate upstream conformance fix #965 (issue #964); merge that fix first.

Related to #767. #908 owns current position, zoned cleaning, and goto; this PR does not duplicate those APIs. The common-coordinate point introduced here follows the maintainer feedback on #908 and is intended to be reused there.

## Summary

- expose typed no-go, no-mop, threshold, and virtual-wall data in common Roborock millimetre coordinates
- add atomic full-collection setters for restricted zones and virtual walls
- add reversible room rename and saved-map apply controls
- keep device pushes authoritative instead of mutating cached map state after a publish
- preserve unknown restriction type bytes and refuse unsafe replacement when the device snapshot is missing, malformed, or contains an unsupported polygon shape

## Protocol and safety

Binary packing lives in the B01 protocol layer. Public APIs accept structured immutable points, restrictions, and walls rather than base64 or raw Q10 vector units. Coordinates must align to the device's 5 mm vector grid and fit signed 16-bit wire values.

Restriction and wall writes replace the entire stored collection. The restriction setter therefore requires a complete, representable DP 55 snapshot before publishing. Invalid geometry, duplicate points, unsupported cardinality, invalid types, overflow, and excessive collection sizes fail before any command is sent.

Saved-map `apply` remains asynchronous and does not optimistically alter the cached map list. The existing `select` operation remains preview-only.

## Validation

- `uv run pytest -q`: **1127 passed**, **89 snapshots passed**
- `uv run pre-commit run --all-files`: passed, including Ruff, mypy, codespell, structured-file checks, and private-key detection
- `uv build`: passed repeatedly for both sdist and wheel
- byte-exact encoder tests cover real multi-zone and mixed-orientation wall captures, canonical empty payloads, signed boundaries, unknown type preservation, and caller immutability
- validated on a physical Q10 S5+: applied and observed a temporary no-go zone, virtual wall, and room rename; restored every original value and verified the robot remained docked/charging
- exercised saved-map `apply` and readback safely; this device currently has one saved map, so a cross-map transition was not available to test
- installed the exact final wheel into local Home Assistant and verified integration startup plus a complete live map image with no new integration/backend errors

No credentials, identifiers, personal room labels, floorplans, or private packet captures are included.

## Deliberate exclusions

- room split/merge and map delete/reset are destructive and were not tested on the primary household map
- map rename lacks a fully captured request shape on this firmware
- per-room repeat, route, fan, and mop settings remain a separate cleaning-controls contribution pending one-factor-at-a-time captures
- current position, zoned cleaning, and goto remain in #908

## Reviewer guide

1. `Q10RoborockPoint` and overlay models: public coordinate/type boundary
2. B01 protocol encoders: framing, geometry validation, range checks, and fixed room-name field
3. Q10 map traits: snapshot safety, exact `COMMON` envelopes, and push-authoritative state
4. protocol and trait tests: real captures, malformed inputs, no-publish failures, and replacement semantics

## Latest maintenance validation

- Updated against upstream `eac001c`; isolated upstream conformance fix tracked in #964 / #965.
- Full suite: **1485 passed, 53 existing xfailed**, **92 snapshots passed**.
- All pre-commit checks and wheel/sdist builds passed.
- No new physical-device run for this revision.
