### PR TITLE
feat: parse Q10 archived map packets

### DIFF
--- a/roborock/cli.py
+++ b/roborock/cli.py
@@ -594,9 +594,9 @@ async def maps(ctx, device_id: str):
     await _display_v1_trait(context, device_id, lambda v1: v1.maps)
 
 
-# The Q10 publishes its map asynchronously after a dpMultiMap list/get request.
-# Firmware throttles pushes to ~once per 60-70s, so rapid re-requests may not be
-# answered immediately. This bounds how long a one-shot CLI command waits.
+# The Q10 publishes its current map asynchronously after a REQUEST_DPS. Firmware
+# throttles pushes to ~once per 60-70s, so rapid re-requests may not be answered
+# immediately. This bounds how long a one-shot CLI command waits.
 _Q10_MAP_PUSH_TIMEOUT = 30.0
 
 
@@ -609,10 +609,9 @@ async def _await_q10_map_push(
 ) -> bool:
     """Request Q10 map content and wait for usable map-trait state.
 
-    A Q10 needs a saved-map ID before it can request content. The map list and
-    content have independent refresh schedules, so the list is requested only
-    when no ID is stored. The content then arrives as a later ``MAP_RESPONSE``
-    and is published through the standard trait update interface.
+    The read-only ``REQUEST_DPS`` request returns immediately; current map
+    content arrives as a later ``MAP_RESPONSE`` and is published through the
+    standard trait update interface.
     """
     loop = asyncio.get_running_loop()
     updated: asyncio.Future[None] = loop.create_future()
@@ -624,20 +623,6 @@ async def _await_q10_map_push(
     unsub = properties.map.add_update_listener(on_update)
     try:
         async with asyncio.timeout(timeout):
-            if properties.maps.current_map_id is None:
-                map_list_updated: asyncio.Future[None] = loop.create_future()
-
-                def on_map_list_update() -> None:
-                    if properties.maps.current_map_id is not None and not map_list_updated.done():
-                        map_list_updated.set_result(None)
-
-                unsub_maps = properties.maps.add_update_listener(on_map_list_update)
-                try:
-                    await properties.maps.refresh()
-                    if properties.maps.current_map_id is None:
-                        await map_list_updated
-                finally:
-                    unsub_maps()
             await properties.map.refresh()
             await updated
         return True

--- a/roborock/devices/traits/b01/q10/map.py
+++ b/roborock/devices/traits/b01/q10/map.py
@@ -7,10 +7,10 @@ Map-related state arrives on three independent streams:
 * restricted zones, virtual walls and dock state arrive as ordinary DPS values.
 
 ``MapDpsTrait`` owns the low-level map-specific DPS read model.
-``MapContentTrait`` uses a stored ID from ``MapsTrait`` only when it requests
-content. It combines the latest map and trace packets with the map DPS state
-through the pure functions in :mod:`roborock.map.b01_q10_render`. Map-list
-updates do not refresh content.
+``MapContentTrait`` requests a current-map push through ``REQUEST_DPS`` and
+combines the latest map and trace packets with the map DPS state through the
+pure functions in :mod:`roborock.map.b01_q10_render`. Saved-map list/detail
+operations remain on ``MapsTrait``.
 """
 
 import logging
@@ -107,20 +107,13 @@ class MapContentTrait(TraitUpdateListener):
         self._map_dps.add_update_listener(self._map_dps_updated)
 
     async def refresh(self) -> None:
-        """Request content for the first map in the latest saved-map list."""
-        if (map_id := self._maps.current_map_id) is None:
-            raise RoborockException("Cannot request Q10 map content before the map list is available")
-        # Map lists and map content can change at different times. Reuse the
-        # stored ID so a content refresh does not also refresh the list.
-        await self._command.send(
-            B01_Q10_DP.COMMON,
-            {
-                str(B01_Q10_DP.MULTI_MAP.code): {
-                    "op": "get",
-                    "id": map_id,
-                }
-            },
-        )
+        """Request a safe asynchronous current-map/status push.
+
+        Some ss07 firmware treats ``dpMultiMap op:get`` as an active
+        cleaning/relocation command. ``REQUEST_DPS`` is the device's read-only
+        current-map request and does not depend on a saved-map ID.
+        """
+        await self._command.send(B01_Q10_DP.REQUEST_DPS, params={})
 
     @property
     def image_content(self) -> bytes | None:

--- a/roborock/map/b01_q10_map_parser.py
+++ b/roborock/map/b01_q10_map_parser.py
@@ -1,8 +1,9 @@
 """Parser for Roborock Q10 (B01/ss07) map packets.
 
-Q10 devices deliver map data as a protocol-301 ``MAP_RESPONSE`` message after a
-``dpMultiMap`` list/get request. Unlike the Q7 ``SCMap`` protobuf
-format, the Q10 uses a custom, unencrypted binary packet:
+Q10 devices deliver map data as protocol-301 ``MAP_RESPONSE`` pushes. Current
+maps follow a read-only status request, while saved-map and clean-record detail
+packets follow their respective ``select`` requests. Unlike the Q7 ``SCMap``
+protobuf format, the Q10 uses a custom, unencrypted binary packet:
 
 - ``01 01`` marker, then a ``u32be`` map id (bytes 2-5) and two consecutive
   ``u16be`` dimensions: grid width (bytes 7-8) and grid height (bytes 9-10).
@@ -22,6 +23,7 @@ https://github.com/v1b3c0d3x3r/roborock-qseries-map-bridge
 import io
 import math
 import statistics
+import struct
 from dataclasses import dataclass, field, replace
 
 from PIL import Image
@@ -29,6 +31,7 @@ from vacuum_map_parser_base.config.color import ColorsPalette, SupportedColor
 from vacuum_map_parser_base.config.image_config import ImageConfig
 from vacuum_map_parser_base.map_data import ImageData, MapData, Point
 
+from roborock.data.code_mappings import RoborockEnum
 from roborock.data.containers import RoborockBase
 from roborock.exceptions import RoborockException
 
@@ -66,9 +69,6 @@ def classify_q10_cell(value: int) -> str:
     return LAYER_FLOOR
 
 
-MAP_PACKET_MARKER = b"\x01\x01"
-TRACE_PACKET_MARKER = b"\x02\x01"
-
 _MAP_ID_OFFSET = 2
 # Width and height are two consecutive u16be fields. An earlier revision read the
 # width as u16le at offset 8; that high byte is actually the height's high byte,
@@ -83,6 +83,7 @@ _LAYOUT_COMPRESSED_OFFSET = 29
 _ROOM_RECORD_LENGTH = 47
 _ROOM_NAME_LENGTH_OFFSET = 26
 _MAX_ROOMS = 32
+_MAX_GRID_CELLS = 16_000_000
 # Sanity bound for the erase-zone vector section's vertices-per-polygon field.
 _MAX_ERASE_ZONE_VERTICES = 16
 
@@ -194,10 +195,30 @@ class Q10HeaderCalibration:
         )
 
 
+class Q10MapPacketKind(RoborockEnum):
+    """Semantic kind identified by a Q10 map packet's two-byte marker."""
+
+    CURRENT = 1
+    TRACE = 2
+    CLEAN_RECORD_DETAIL = 3
+    SAVED_MAP_DETAIL = 4
+
+    @property
+    def marker(self) -> bytes:
+        """Return the two-byte wire marker for this packet kind."""
+        return bytes((self.value, 1))
+
+    @classmethod
+    def from_payload(cls, payload: bytes) -> "Q10MapPacketKind | None":
+        """Return the recognized kind for a payload marker."""
+        return next((kind for kind in cls if payload[:2] == kind.marker), None)
+
+
 @dataclass
 class Q10MapPacket:
-    """Decoded contents of a Q10 ``01 01`` map packet."""
+    """Decoded contents of a Q10 current or archived map packet."""
 
+    kind: Q10MapPacketKind
     map_id: int
     width: int
     height: int
@@ -211,6 +232,8 @@ class Q10MapPacket:
     """Carpet mask decoded from the packet tail: a full ``width*height`` grid in
     the same (top-down) pixel space as :attr:`grid`, where a non-zero cell is
     carpet (the value is the carpet kind). ``None`` if the packet carried none."""
+    historical_trace: "Q10HistoricalTracePacket | None" = None
+    """Cleaning path embedded in a clean-record detail packet, if present."""
 
     @property
     def layers(self) -> GridLayers:
@@ -266,6 +289,27 @@ class Q10TracePacket:
         return self.points[-1] if self.points else None
 
 
+@dataclass
+class Q10HistoricalTracePacket:
+    """Cleaning path embedded in a Q10 ``03 01`` clean-record detail packet.
+
+    This is a different wire layout from the live ``02 01`` trace. Its header
+    carries a 16-bit format version, a 32-bit opaque value, a 32-bit
+    point count, a signed heading, and a zero reserved word. Points use the same
+    signed big-endian ``(x, y)`` coordinate pairs as the live trace.
+    """
+
+    points: list[Q10Point] = field(default_factory=list)
+    version: int = 0
+    opaque_value: int = 0
+    heading: int = 0
+
+    @property
+    def robot_position(self) -> Q10Point | None:
+        """The final recorded position, if the historical path is non-empty."""
+        return self.points[-1] if self.points else None
+
+
 # Trace packet (``02 01``): a 14-byte header followed by big-endian int16 (x, y)
 # point pairs forming the accumulated session path. Header layout confirmed
 # against live ss07 captures and cross-checked by @andrewlyeats:
@@ -275,17 +319,26 @@ class Q10TracePacket:
 # - bytes 10-11: the 0201 SLAM heading (s16be degrees; 0 = +x, +90 = +y,
 #   +-180 = -x, -90 = -y) -- the robot's current orientation.
 # - bytes 12-13: a constant (0x0000).
-# - byte 14 onward: the path points.
+# - byte 14 onward: exactly ``point_count`` path points.
 # An earlier revision used a 10-byte header, which folded the heading word into
 # a phantom leading point ``(heading, 0)`` -- that is the "stray point" the
 # heuristic below was papering over, and why the count read "one high". The
-# parser reads all 4-byte pairs in the body rather than trusting the count
-# field, so a truncated tail can't desync it.
+# parser requires the declared point count to match the complete body, so a
+# truncated or extended tail cannot be silently interpreted as path data.
 # NOTE: the format documented by roborock-qseries-map-bridge (18-byte header)
 # did not match this firmware -- this 14-byte layout is what the device sent.
 _TRACE_HEADER_LENGTH = 14
 _TRACE_SEQUENCE_OFFSET = 3
+_TRACE_POINT_COUNT_OFFSET = 8
 _TRACE_HEADING_OFFSET = 10
+
+_HISTORICAL_TRACE_HEADER_LENGTH = 14
+_HISTORICAL_TRACE_PREFIX_LENGTH = 1
+_HISTORICAL_TRACE_VERSION = 1
+_HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET = 2
+_HISTORICAL_TRACE_POINT_COUNT_OFFSET = 6
+_HISTORICAL_TRACE_HEADING_OFFSET = 10
+_HISTORICAL_TRACE_RESERVED_OFFSET = 12
 
 # Some cleans still prepend a single near-origin sentinel as the first real
 # point (e.g. ~(5, 76) / (-3, 0) when the path proper starts near (-1700, -800));
@@ -301,12 +354,22 @@ _STRAY_POINT_STEP_RATIO = 20
 
 def is_map_packet(payload: bytes) -> bool:
     """Return True if the payload is a Q10 full-map (``01 01``) packet."""
-    return payload[:2] == MAP_PACKET_MARKER
+    return Q10MapPacketKind.from_payload(payload) is Q10MapPacketKind.CURRENT
+
+
+def is_clean_record_map_packet(payload: bytes) -> bool:
+    """Return True for a Q10 clean-record detail (``03 01``) packet."""
+    return Q10MapPacketKind.from_payload(payload) is Q10MapPacketKind.CLEAN_RECORD_DETAIL
+
+
+def is_saved_map_packet(payload: bytes) -> bool:
+    """Return True for a Q10 saved-map detail (``04 01``) packet."""
+    return Q10MapPacketKind.from_payload(payload) is Q10MapPacketKind.SAVED_MAP_DETAIL
 
 
 def is_trace_packet(payload: bytes) -> bool:
     """Return True if the payload is a Q10 live trace (``02 01``) packet."""
-    return payload[:2] == TRACE_PACKET_MARKER
+    return Q10MapPacketKind.from_payload(payload) is Q10MapPacketKind.TRACE
 
 
 def parse_trace_packet(payload: bytes) -> Q10TracePacket:
@@ -318,6 +381,9 @@ def parse_trace_packet(payload: bytes) -> Q10TracePacket:
     body = payload[_TRACE_HEADER_LENGTH:]
     if len(body) % 4:
         raise RoborockException("Q10 trace points are not 4-byte (x, y) pairs")
+    declared_point_count = int.from_bytes(payload[_TRACE_POINT_COUNT_OFFSET : _TRACE_POINT_COUNT_OFFSET + 2], "big")
+    if declared_point_count != len(body) // 4:
+        raise RoborockException("Q10 trace point count does not match its payload")
 
     heading = int.from_bytes(payload[_TRACE_HEADING_OFFSET : _TRACE_HEADING_OFFSET + 2], "big", signed=True)
     points = [
@@ -348,11 +414,13 @@ def _drop_stray_leading_point(points: list[Q10Point]) -> list[Q10Point]:
     return points
 
 
-def lz4_block_decompress(data: bytes) -> bytes:
+def lz4_block_decompress(data: bytes, max_output_size: int | None = None) -> bytes:
     """Decompress a raw LZ4 *block* (no frame header).
 
     The Q10 map grid is stored as a single LZ4 block. This implements the
-    standard LZ4 block format so we don't add a native dependency.
+    standard LZ4 block format so we don't add a native dependency. When
+    ``max_output_size`` is supplied, expansion beyond it is rejected before
+    allocating the excess output.
     """
     index = 0
     output = bytearray()
@@ -380,6 +448,8 @@ def lz4_block_decompress(data: bytes) -> bytes:
         end = index + literal_length
         if end > len(data):
             raise RoborockException("Truncated LZ4 block while reading literals")
+        if max_output_size is not None and len(output) + literal_length > max_output_size:
+            raise RoborockException("LZ4 block exceeds maximum output size")
         output.extend(data[index:end])
         index = end
 
@@ -394,6 +464,8 @@ def lz4_block_decompress(data: bytes) -> bytes:
             raise RoborockException("Invalid LZ4 back-reference offset")
 
         match_length = read_length(token & 0x0F) + 4
+        if max_output_size is not None and len(output) + match_length > max_output_size:
+            raise RoborockException("LZ4 block exceeds maximum output size")
         for _ in range(match_length):
             output.append(output[-offset])
 
@@ -458,8 +530,9 @@ def _parse_rooms(room_data: bytes, grid: bytes) -> list[Q10Room]:
 
 
 def parse_map_packet(payload: bytes) -> Q10MapPacket:
-    """Parse a Q10 ``01 01`` map packet into grid + room metadata."""
-    if len(payload) < _LAYOUT_COMPRESSED_OFFSET or not is_map_packet(payload):
+    """Parse a Q10 current or archived map into typed source data."""
+    kind = Q10MapPacketKind.from_payload(payload)
+    if len(payload) < _LAYOUT_COMPRESSED_OFFSET or kind is None or kind is Q10MapPacketKind.TRACE:
         raise RoborockException("Payload is not a Q10 map packet")
 
     map_id = int.from_bytes(payload[_MAP_ID_OFFSET : _MAP_ID_OFFSET + 4], "big")
@@ -467,6 +540,8 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
     height = int.from_bytes(payload[_HEIGHT_OFFSET : _HEIGHT_OFFSET + 2], "big")
     if width <= 0:
         raise RoborockException("Q10 map packet has invalid width")
+    if height > 0 and width * height > _MAX_GRID_CELLS:
+        raise RoborockException("Q10 map packet dimensions exceed the supported grid size")
 
     compressed_length = int.from_bytes(
         payload[_COMPRESSED_LAYOUT_LENGTH_OFFSET : _COMPRESSED_LAYOUT_LENGTH_OFFSET + 2], "big"
@@ -475,7 +550,10 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
     if compressed_length <= 0 or layout_end > len(payload):
         raise RoborockException("Q10 map packet has invalid layout block length")
 
-    decoded = lz4_block_decompress(payload[_LAYOUT_COMPRESSED_OFFSET:layout_end])
+    decoded = lz4_block_decompress(
+        payload[_LAYOUT_COMPRESSED_OFFSET:layout_end],
+        max_output_size=_MAX_GRID_CELLS + 2 + _MAX_ROOMS * _ROOM_RECORD_LENGTH,
+    )
     # Prefer the header height; fall back to inference if it doesn't line up
     # (e.g. older captures/fixtures that don't populate the height field).
     split = _split_with_dims(decoded, width, height) if height > 0 else None
@@ -486,9 +564,14 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
     rooms = _parse_rooms(room_data, grid)
     tail = payload[layout_end:]
     erase_zones = _parse_erase_zones(tail)
-    carpet_mask = _parse_carpet_mask(tail, width, height)
+    carpet_mask, carpet_end = _parse_carpet_block(tail, width, height)
+    if kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL and carpet_end is not None:
+        historical_trace, _ = _parse_clean_record_trace(tail, carpet_end)
+    else:
+        historical_trace = None
     header_calibration = _parse_header_calibration(payload)
     return Q10MapPacket(
+        kind=kind,
         map_id=map_id,
         width=width,
         height=height,
@@ -497,6 +580,7 @@ def parse_map_packet(payload: bytes) -> Q10MapPacket:
         erase_zones=erase_zones,
         header_calibration=header_calibration,
         carpet_mask=carpet_mask,
+        historical_trace=historical_trace,
     )
 
 
@@ -569,7 +653,18 @@ def _carpet_offset(tail: bytes) -> int:
     return 2 + count * vertices_per * 4
 
 
-def _parse_carpet_mask(tail: bytes, width: int, height: int) -> bytes | None:
+def _erase_section_end(tail: bytes) -> int:
+    """Return the end of a complete, structurally valid erase section."""
+    if len(tail) < 2:
+        return 0
+    count, vertices_per = tail[0], tail[1]
+    if count and not 1 <= vertices_per <= _MAX_ERASE_ZONE_VERTICES:
+        return 0
+    end = _carpet_offset(tail)
+    return end if end <= len(tail) else 0
+
+
+def _parse_carpet_block(tail: bytes, width: int, height: int) -> tuple[bytes | None, int | None]:
     """Decode the carpet mask that follows the erase section in the packet tail.
 
     Framing matches the main grid block: ``[u32 uncompressed_len]``
@@ -578,23 +673,88 @@ def _parse_carpet_mask(tail: bytes, width: int, height: int) -> bytes | None:
     non-zero cell is carpet (the value is the carpet kind). Confirmed byte-exact
     on live ss07 captures (R1 / RDC), where ``uncompressed_len == width*height``.
 
-    Returns the decompressed mask, or ``None`` if the section is absent or does
-    not line up (the ``uncompressed_len == width*height`` invariant is used as the
-    guard so a mis-located section yields no carpet rather than garbage).
+    Returns the decompressed mask and its end offset. Both are ``None`` if the
+    section is absent or does not line up. The end offset is used to anchor
+    optional later sections without scanning arbitrary trailing bytes.
     """
-    offset = _carpet_offset(tail)
+    offset = _erase_section_end(tail)
+    if offset == 0:
+        return None, None
     if offset + 6 > len(tail):
-        return None
+        return None, None
     uncompressed_len = int.from_bytes(tail[offset : offset + 4], "big")
     compressed_len = int.from_bytes(tail[offset + 4 : offset + 6], "big")
     block_end = offset + 6 + compressed_len
     if uncompressed_len != width * height or compressed_len <= 0 or block_end > len(tail):
-        return None
+        return None, None
     try:
-        mask = lz4_block_decompress(tail[offset + 6 : block_end])
+        mask = lz4_block_decompress(tail[offset + 6 : block_end], max_output_size=width * height)
     except RoborockException:
-        return None
-    return mask if len(mask) == width * height else None
+        return None, None
+    if len(mask) != width * height:
+        return None, None
+    return mask, block_end
+
+
+def _parse_carpet_mask(tail: bytes, width: int, height: int) -> bytes | None:
+    """Decode only the optional carpet mask (compatibility helper)."""
+    return _parse_carpet_block(tail, width, height)[0]
+
+
+def _parse_clean_record_trace(
+    tail: bytes,
+    offset: int,
+) -> tuple[Q10HistoricalTracePacket | None, int | None]:
+    """Decode the bounded historical path following a ``03 01`` carpet block.
+
+    The header and declared point count were validated against a physical ss07
+    clean-record response and its point bytes match captured prefixes of the
+    corresponding live trace exactly. One observed zero byte precedes the path;
+    its meaning is unknown, so a non-zero value makes the entire section opaque.
+    Any unsupported version, non-zero reserved word, or truncated point table is
+    likewise left completely opaque. Bytes after the declared points are
+    deliberately not consumed: the observed 12-byte suffix appears structured,
+    but there is not enough controlled evidence to name or decode it safely.
+    """
+    if offset >= len(tail) or tail[offset] != 0:
+        return None, None
+    offset += _HISTORICAL_TRACE_PREFIX_LENGTH
+    header_end = offset + _HISTORICAL_TRACE_HEADER_LENGTH
+    if header_end > len(tail):
+        return None, None
+    version = int.from_bytes(tail[offset : offset + 2], "big")
+    reserved = int.from_bytes(
+        tail[offset + _HISTORICAL_TRACE_RESERVED_OFFSET : offset + _HISTORICAL_TRACE_RESERVED_OFFSET + 2],
+        "big",
+    )
+    if version != _HISTORICAL_TRACE_VERSION or reserved != 0:
+        return None, None
+    point_count = int.from_bytes(
+        tail[offset + _HISTORICAL_TRACE_POINT_COUNT_OFFSET : offset + _HISTORICAL_TRACE_POINT_COUNT_OFFSET + 4],
+        "big",
+    )
+    points_end = header_end + point_count * 4
+    if points_end > len(tail):
+        return None, None
+    coordinates = struct.iter_unpack(">hh", memoryview(tail)[header_end:points_end])
+    return (
+        Q10HistoricalTracePacket(
+            points=[Q10Point(x=x, y=y) for x, y in coordinates],
+            version=version,
+            opaque_value=int.from_bytes(
+                tail[
+                    offset + _HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET : offset + _HISTORICAL_TRACE_OPAQUE_VALUE_OFFSET + 4
+                ],
+                "big",
+            ),
+            heading=int.from_bytes(
+                tail[offset + _HISTORICAL_TRACE_HEADING_OFFSET : offset + _HISTORICAL_TRACE_HEADING_OFFSET + 2],
+                "big",
+                signed=True,
+            ),
+        ),
+        points_end,
+    )
 
 
 def erased_packet(packet: "Q10MapPacket", cells: set[int]) -> "Q10MapPacket":

--- a/roborock/map/b01_q10_render.py
+++ b/roborock/map/b01_q10_render.py
@@ -34,6 +34,7 @@ from .b01_q10_map_parser import (
     B01Q10MapParser,
     B01Q10MapParserConfig,
     Q10EraseZone,
+    Q10HistoricalTracePacket,
     Q10MapPacket,
     Q10TracePacket,
     erased_packet,
@@ -62,7 +63,6 @@ _MIN_CALIBRATION_POINTS = 20
 # a much shorter path suffices to confirm it (early in a clean, not just a dense
 # one). See :func:`solve_calibration_with_origin`.
 _MIN_HEADER_CALIBRATION_POINTS = 4
-
 _Q10_DRAWABLE_TYPES = {
     Drawable.CHARGER,
     Drawable.NO_GO_AREAS,
@@ -84,7 +84,7 @@ class Q10MapOverlays:
 
 def render_q10_map(
     packet: Q10MapPacket,
-    trace: Q10TracePacket | None,
+    trace: Q10TracePacket | Q10HistoricalTracePacket | None,
     overlays: Q10MapOverlays,
     *,
     config: B01Q10MapParserConfig,
@@ -133,7 +133,7 @@ def render_q10_map(
 
 def solve_q10_calibration(
     packet: Q10MapPacket,
-    trace: Q10TracePacket | None,
+    trace: Q10TracePacket | Q10HistoricalTracePacket | None,
 ) -> GridCalibration | None:
     """Derive world-to-pixel calibration from a map and its current trace.
 
@@ -232,7 +232,7 @@ def _erased_cells(
 def _place_trace(
     map_data: MapData,
     calibration: GridCalibration,
-    trace: Q10TracePacket,
+    trace: Q10TracePacket | Q10HistoricalTracePacket,
     *,
     charger_heading: int | None = None,
 ) -> None:

--- a/roborock/protocols/b01_q10_protocol.py
+++ b/roborock/protocols/b01_q10_protocol.py
@@ -9,9 +9,8 @@ from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
 from roborock.exceptions import RoborockException
 from roborock.map.b01_q10_map_parser import (
     Q10MapPacket,
+    Q10MapPacketKind,
     Q10TracePacket,
-    is_map_packet,
-    is_trace_packet,
     parse_map_packet,
     parse_trace_packet,
 )
@@ -113,18 +112,18 @@ Q10Message = Q10DpsUpdate | Q10MapPacket | Q10TracePacket
 def decode_message(message: RoborockMessage) -> Q10Message | None:
     """Decode a pushed Q10 ``RoborockMessage`` into a typed message.
 
-    ``MAP_RESPONSE`` (protocol 301) payloads carry the binary map (``01 01``) or
-    trace (``02 01``) packets, which are parsed by the map parser; any other
-    ``MAP_RESPONSE`` marker is unrecognized and yields ``None``. Every other
-    protocol is treated as a DPS status update.
+    ``MAP_RESPONSE`` (protocol 301) payloads carry binary current-map (``01
+    01``), trace (``02 01``), clean-record detail (``03 01``), or saved-map
+    detail (``04 01``) packets. Any other marker is unrecognized and yields
+    ``None``. Every other protocol is treated as a DPS status update.
 
     Raises ``RoborockException`` if a recognized payload fails to parse.
     """
     if message.protocol == RoborockMessageProtocol.MAP_RESPONSE:
         payload = message.payload or b""
-        if is_map_packet(payload):
-            return parse_map_packet(payload)
-        if is_trace_packet(payload):
+        if Q10MapPacketKind.from_payload(payload) is Q10MapPacketKind.TRACE:
             return parse_trace_packet(payload)
+        if Q10MapPacketKind.from_payload(payload) is not None:
+            return parse_map_packet(payload)
         return None
     return Q10DpsUpdate(dps=decode_rpc_response(message))

--- a/tests/devices/traits/b01/q10/test_map.py
+++ b/tests/devices/traits/b01/q10/test_map.py
@@ -140,34 +140,6 @@ class _FakeQ10PropertiesWithTrace(_FakeQ10Properties):
         self.map.refresh = refresh_map  # type: ignore[method-assign]
 
 
-class _FakeQ10PropertiesWithoutMapId:
-    def __init__(self) -> None:
-        command = cast(CommandTrait, Mock(spec=CommandTrait))
-        self.maps = MapsTrait(command)
-        self.map = MapContentTrait(MapDpsTrait(), self.maps, command)
-        self.maps_refresh_count = 0
-        self.map_refresh_count = 0
-
-        async def refresh_maps() -> None:
-            self.maps_refresh_count += 1
-            self.maps.update_from_dps(
-                {
-                    B01_Q10_DP.MULTI_MAP: {
-                        "data": [{"id": "12345"}],
-                        "op": "list",
-                        "result": 1,
-                    }
-                }
-            )
-
-        async def refresh_map() -> None:
-            self.map_refresh_count += 1
-            self.map.update_from_trace_packet(parse_trace_packet(TRACE_SESSION_FIXTURE.read_bytes()))
-
-        self.maps.refresh = refresh_maps  # type: ignore[method-assign]
-        self.map.refresh = refresh_map  # type: ignore[method-assign]
-
-
 async def test_await_q10_map_push_waits_for_fresh_update() -> None:
     """A cached trace alone is not treated as a successful new map push."""
     properties = _FakeQ10Properties()
@@ -194,21 +166,6 @@ async def test_await_q10_map_push_returns_true_after_update() -> None:
 
     assert got_trace is True
     assert len(properties.map.path) == 14
-
-
-async def test_await_q10_map_push_requests_map_list_only_on_first_use() -> None:
-    """Content gets the list first only when no stored map ID is available."""
-    properties = _FakeQ10PropertiesWithoutMapId()
-
-    got_trace = await _await_q10_map_push(
-        cast(Q10PropertiesApi, properties),
-        lambda: bool(properties.map.path),
-        timeout=0.01,
-    )
-
-    assert got_trace is True
-    assert properties.maps_refresh_count == 1
-    assert properties.map_refresh_count == 1
 
 
 async def test_await_q10_map_push_can_fall_back_to_cached_map_on_timeout() -> None:
@@ -286,7 +243,7 @@ async def test_subscribe_loop_routes_trace_push(
     assert q10_api.map.robot_position is not None
 
 
-async def test_map_list_and_content_refresh_are_independent(
+async def test_map_list_and_current_content_refresh_are_independent(
     q10_api: Q10PropertiesApi,
     mock_channel: FakeB01Q10Channel,
     message_queue: asyncio.Queue[Q10Message],
@@ -320,15 +277,7 @@ async def test_map_list_and_content_refresh_are_independent(
 
     await q10_api.map.refresh()
 
-    assert mock_channel.published_commands[1] == (
-        B01_Q10_DP.COMMON,
-        {
-            str(B01_Q10_DP.MULTI_MAP.code): {
-                "op": "get",
-                "id": "12345",
-            }
-        },
-    )
+    assert mock_channel.published_commands[1] == (B01_Q10_DP.REQUEST_DPS, {})
     assert q10_api.maps.current_map_id == "12345"
 
 
@@ -355,10 +304,14 @@ async def test_empty_map_list_does_not_request_content(
     assert mock_channel.published_commands == []
 
 
-async def test_map_content_refresh_requires_stored_map_id(q10_api: Q10PropertiesApi) -> None:
-    """Content cannot be requested until the map list supplies an ID."""
-    with pytest.raises(RoborockException, match="map list is available"):
-        await q10_api.map.refresh()
+async def test_map_content_refresh_does_not_require_stored_map_id(
+    q10_api: Q10PropertiesApi,
+    mock_channel: FakeB01Q10Channel,
+) -> None:
+    """Current-map refresh is read-only and independent of saved-map state."""
+    await q10_api.map.refresh()
+
+    assert mock_channel.published_commands == [(B01_Q10_DP.REQUEST_DPS, {})]
 
 
 async def test_map_content_refresh_requests_are_not_rate_limited(q10_api: Q10PropertiesApi) -> None:

--- a/tests/map/test_b01_q10_map_parser.py
+++ b/tests/map/test_b01_q10_map_parser.py
@@ -2,6 +2,7 @@
 
 import io
 from pathlib import Path
+from typing import Any
 
 import pytest
 from PIL import Image
@@ -10,9 +11,13 @@ from roborock.exceptions import RoborockException
 from roborock.map.b01_grid_layers import LAYER_BACKGROUND, LAYER_FLOOR, LAYER_WALL
 from roborock.map.b01_q10_map_parser import (
     B01Q10MapParser,
+    Q10MapPacketKind,
+    Q10Point,
     Q10Room,
     classify_q10_cell,
+    is_clean_record_map_packet,
     is_map_packet,
+    is_saved_map_packet,
     is_trace_packet,
     lz4_block_decompress,
     parse_map_packet,
@@ -105,6 +110,13 @@ def test_lz4_block_back_reference() -> None:
     # seq2: final literals-only token (0 literals) ends the block per LZ4 spec.
     block = bytes([0x14, ord("A"), 0x01, 0x00, 0x00])
     assert lz4_block_decompress(block) == b"A" * 9
+
+
+def test_lz4_block_rejects_output_over_limit() -> None:
+    block = bytes([0x14, ord("A"), 0x01, 0x00, 0x00])
+
+    with pytest.raises(RoborockException, match="maximum output size"):
+        lz4_block_decompress(block, max_output_size=8)
 
 
 def test_is_map_packet() -> None:
@@ -356,10 +368,29 @@ def test_parse_trace_rejects_misaligned_points() -> None:
         parse_trace_packet(b"\x02\x01" + b"\x00" * 12 + b"\x01\x02\x03")
 
 
+@pytest.mark.parametrize("declared_count", [0, 2])
+def test_parse_trace_rejects_declared_count_mismatch(declared_count: int) -> None:
+    """An aligned body cannot silently disagree with the firmware count."""
+    payload = bytearray(_trace_payload([(10, 20)]))
+    payload[8:10] = declared_count.to_bytes(2, "big")
+
+    with pytest.raises(RoborockException, match="point count"):
+        parse_trace_packet(bytes(payload))
+
+
 def test_parse_rejects_bad_layout_length() -> None:
     payload = bytearray(_payload())
     payload[27:29] = (0xFFFF).to_bytes(2, "big")  # compressed length past the buffer
     with pytest.raises(RoborockException, match="invalid layout block length"):
+        parse_map_packet(bytes(payload))
+
+
+def test_parse_rejects_unreasonable_header_dimensions() -> None:
+    payload = bytearray(_payload())
+    payload[7:9] = (65535).to_bytes(2, "big")
+    payload[9:11] = (65535).to_bytes(2, "big")
+
+    with pytest.raises(RoborockException, match="supported grid size"):
         parse_map_packet(bytes(payload))
 
 
@@ -385,6 +416,32 @@ def _carpet_tail(width: int, height: int, carpet: bytes, erase: bytes = bytes([0
     """Build a packet tail: an erase section followed by a carpet-mask section."""
     block = _literal_lz4_block(carpet)
     return erase + (width * height).to_bytes(4, "big") + len(block).to_bytes(2, "big") + block
+
+
+def _map_detail_payload(
+    marker: bytes,
+    points: list[tuple[int, int]],
+    *,
+    version: int = 1,
+    opaque_value: int = 2,
+    heading: int = 3,
+    reserved: int = 0,
+    prefix: int = 0,
+    trailing: bytes = b"",
+) -> bytes:
+    """Build a neutral synthetic detail packet from the existing map fixture."""
+    header = (
+        version.to_bytes(2, "big")
+        + opaque_value.to_bytes(4, "big")
+        + len(points).to_bytes(4, "big")
+        + heading.to_bytes(2, "big", signed=True)
+        + reserved.to_bytes(2, "big")
+    )
+    point_table = b"".join(x.to_bytes(2, "big", signed=True) + y.to_bytes(2, "big", signed=True) for x, y in points)
+    history = bytes([prefix]) + header + point_table
+    payload = bytearray(FIXTURE.read_bytes() + _carpet_tail(8, 6, bytes(48)) + history + trailing)
+    payload[:2] = marker
+    return bytes(payload)
 
 
 def test_parse_carpet_mask_from_map_packet_tail() -> None:
@@ -413,6 +470,84 @@ def test_parse_carpet_mask_from_map_packet_tail() -> None:
 
 def test_parse_map_packet_without_carpet() -> None:
     assert parse_map_packet(FIXTURE.read_bytes()).carpet_mask is None
+
+
+def test_classify_current_clean_record_and_saved_map_packets() -> None:
+    """All known map markers retain an explicit semantic kind."""
+    current = FIXTURE.read_bytes()
+    clean_record = _map_detail_payload(b"\x03\x01", [(10, -20)])
+    saved_map = _map_detail_payload(b"\x04\x01", [(10, -20)])
+
+    assert is_map_packet(current)
+    assert is_clean_record_map_packet(clean_record)
+    assert is_saved_map_packet(saved_map)
+    assert parse_map_packet(current).kind is Q10MapPacketKind.CURRENT
+    assert parse_map_packet(clean_record).kind is Q10MapPacketKind.CLEAN_RECORD_DETAIL
+    assert parse_map_packet(saved_map).kind is Q10MapPacketKind.SAVED_MAP_DETAIL
+
+
+def test_parse_clean_record_historical_trace_with_unknown_tail() -> None:
+    """The bounded historical path is decoded without interpreting later bytes."""
+    packet = parse_map_packet(_map_detail_payload(b"\x03\x01", [(10, -20), (-30, 40)], trailing=b"future-section"))
+
+    assert packet.historical_trace is not None
+    assert [(point.x, point.y) for point in packet.historical_trace.points] == [(10, -20), (-30, 40)]
+    assert packet.historical_trace.version == 1
+    assert packet.historical_trace.opaque_value == 2
+    assert packet.historical_trace.heading == 3
+    assert packet.historical_trace.robot_position == Q10Point(-30, 40)
+
+
+def test_zero_point_historical_trace_with_following_section() -> None:
+    """A zero-point path remains valid when a later section follows it."""
+    packet = parse_map_packet(_map_detail_payload(b"\x03\x01", [], trailing=b"recorded-path"))
+
+    assert packet.historical_trace is not None
+    assert packet.historical_trace.points == []
+
+
+def test_historical_trace_is_not_inferred_for_other_packet_kinds() -> None:
+    """The validated ``03 01`` layout is not assumed for current or saved maps."""
+    current = parse_map_packet(_map_detail_payload(b"\x01\x01", [(10, -20)]))
+    saved_map = parse_map_packet(_map_detail_payload(b"\x04\x01", [(10, -20)]))
+
+    assert current.historical_trace is None
+    assert saved_map.historical_trace is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"version": 2},
+        {"reserved": 1},
+        {"prefix": 1},
+    ],
+)
+def test_unsupported_historical_trace_header_is_ignored(kwargs: dict[str, Any]) -> None:
+    payload = _map_detail_payload(b"\x03\x01", [(10, -20)], **kwargs)
+    packet = parse_map_packet(payload)
+
+    assert packet.historical_trace is None
+
+
+def test_truncated_historical_trace_is_ignored() -> None:
+    payload = _map_detail_payload(b"\x03\x01", [(10, -20)])[:-2]
+    packet = parse_map_packet(payload)
+
+    assert packet.historical_trace is None
+
+
+def test_invalid_erase_section_is_ignored() -> None:
+    """An invalid erase header cannot become an anchor for later sections."""
+    tail = b"\x01\xffopaque-tail"
+    payload = bytearray(FIXTURE.read_bytes() + tail)
+    payload[:2] = b"\x03\x01"
+
+    packet = parse_map_packet(bytes(payload))
+
+    assert packet.erase_zones == []
+    assert packet.carpet_mask is None
+    assert packet.historical_trace is None
 
 
 def test_carpet_mask_ignored_when_uncompressed_len_mismatches() -> None:

--- a/tests/map/test_b01_q10_render.py
+++ b/tests/map/test_b01_q10_render.py
@@ -18,6 +18,7 @@ from roborock.map.b01_q10_map_parser import (
     B01Q10MapParserConfig,
     Q10EraseZone,
     Q10HeaderCalibration,
+    Q10HistoricalTracePacket,
     Q10MapPacket,
     Q10Point,
     Q10TracePacket,
@@ -58,7 +59,7 @@ def _packet() -> Q10MapPacket:
 def _render(
     packet: Q10MapPacket | None = None,
     *,
-    trace: Q10TracePacket | None = None,
+    trace: Q10TracePacket | Q10HistoricalTracePacket | None = None,
     overlays: Q10MapOverlays | None = None,
 ) -> bytes:
     return render_q10_map(
@@ -115,6 +116,14 @@ def test_render_draws_path_and_position() -> None:
     assert rendered.size == (8 * 4, 6 * 4)
     # The shared V1 robot glyph has a white body at its center.
     assert rendered.getpixel(image_position) == (255, 255, 255, 255)
+
+
+def test_render_accepts_historical_trace() -> None:
+    """A validated clean-record path uses the same calibrated drawing path."""
+    packet, live_trace = _calibrated_inputs()
+    historical = Q10HistoricalTracePacket(points=live_trace.points, heading=live_trace.heading)
+
+    assert _render(packet, trace=historical) == _render(packet, trace=live_trace)
 
 
 def test_render_draws_zones_and_virtual_walls() -> None:

--- a/tests/protocols/test_b01_q10_protocol.py
+++ b/tests/protocols/test_b01_q10_protocol.py
@@ -13,7 +13,7 @@ from syrupy import SnapshotAssertion
 from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXWaterLevel
 from roborock.data.code_mappings import completed_warnings
 from roborock.exceptions import RoborockException
-from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10TracePacket
+from roborock.map.b01_q10_map_parser import Q10MapPacket, Q10MapPacketKind, Q10TracePacket
 from roborock.protocols.b01_q10_protocol import (
     Q10DpsUpdate,
     decode_message,
@@ -67,6 +67,22 @@ def test_decode_message_map_packet() -> None:
     decoded = decode_message(message)
     assert isinstance(decoded, Q10MapPacket)
     assert {room.id: room.name for room in decoded.rooms} == {2: "Living Room", 3: "Bedroom"}
+
+
+@pytest.mark.parametrize(
+    ("marker", "kind"),
+    [
+        (b"\x03\x01", Q10MapPacketKind.CLEAN_RECORD_DETAIL),
+        (b"\x04\x01", Q10MapPacketKind.SAVED_MAP_DETAIL),
+    ],
+)
+def test_decode_message_archived_map_packet(marker: bytes, kind: Q10MapPacketKind) -> None:
+    """The decoder recognizes both archived map-detail markers."""
+    fixture = MAP_FIXTURE.read_bytes()
+    decoded = decode_message(_message(marker + fixture[2:], RoborockMessageProtocol.MAP_RESPONSE))
+
+    assert isinstance(decoded, Q10MapPacket)
+    assert decoded.kind is kind
 
 
 def test_decode_message_trace_packet() -> None:


### PR DESCRIPTION
Q10 clean-record and saved-map responses use different packet markers from live maps. This adds bounded archive parsing and a `Q10CleanRecordDetail(map, trace)` response so callers receive the map and historical path together without extending the map raster model.

## Implementation

- Classify current, live-trace, clean-record and saved-map markers with `Q10MapPacketKind`. Unknown values resolve to `unknown` and are ignored rather than defaulting to a current map.
- Decode shared raster fields once; clean-record responses compose that map with an optional historical path.
- Keep `Q10HistoricalTracePacket` limited to points and heading. Validate wire version/reserved fields internally and do not expose the undecoded wire value.
- Apply the same conservative stray-leading-point filter used for live paths. Short paths and ordinary origin points are preserved.
- Render the explicitly supplied map and trace without type-dependent branching or silently ignored arguments.
- Remove unused archive-marker and carpet-mask helpers; require a decompression output bound and return only the consumed trace model.

#937 consumes the new detail object in its clean-history trait. Saved and live map state remain independent. No private map captures or account data are included.

## Dependencies and validation

#933 is merged. Current upstream `main` (`eac001c`, including #908) is integrated. This branch also includes the isolated conformance fix in #965, which addresses the independently reproduced upstream failure tracked in #964; please review/merge that small fix first.

- Full suite: **1349 passed, 53 existing xfailed**, **92 snapshots passed**.
- All pre-commit checks, including Ruff and mypy: passed.
- Wheel and sdist builds: passed.
- Regression coverage includes unknown/truncated markers, unsupported archive framing, malformed paths, stray-point filtering, and explicit historical-path rendering.
- No new physical-device run was performed for this revision.

Related: #767.
