### PR TITLE
fix: skip DP 225 on Zeo H1 (roborock.wm.a63)

### DIFF
--- a/roborock/devices/traits/a01/device_feature.py
+++ b/roborock/devices/traits/a01/device_feature.py
@@ -143,6 +143,13 @@ _UNSUPPORTED_FEATURE_BITS: frozenset[str] = frozenset(
     }
 )
 
+# Devices known to lack DEFAULT_SETTING (DP 225).
+_UNSUPPORTED_DEFAULT_SETTING: frozenset[str] = frozenset(
+    {
+        "roborock.wm.a63",  # H1
+    }
+)
+
 # Series that support UV light (DP 228).
 _UV_LIGHT_SERIES: frozenset[str] = (
     _H1_LITE_SERIES  # a90, a91, a237
@@ -242,6 +249,13 @@ def supports_feature_bits(model: str | None) -> bool:
     return model not in _UNSUPPORTED_FEATURE_BITS
 
 
+def supports_default_setting(model: str | None) -> bool:
+    """H1 (a63) does not support DP 225 even though it has a softener compartment."""
+    if model is None:
+        return True  # conservative: assume yes
+    return model not in _UNSUPPORTED_DEFAULT_SETTING
+
+
 def supports_remote_control(model: str | None) -> bool:
     """Remote control (DP 232) is supported on all overseas models."""
     if model is None:
@@ -308,6 +322,10 @@ def build_force_load_dp_list(model: str | None) -> list[RoborockZeoProtocol]:
     # ── Strip unsupported FEATURE_BITS ──
     if not supports_feature_bits(model):
         base = [dp for dp in base if dp != RoborockZeoProtocol.FEATURE_BITS]
+
+    # ── Strip unsupported DEFAULT_SETTING ──
+    if not supports_default_setting(model):
+        base = [dp for dp in base if dp != RoborockZeoProtocol.DEFAULT_SETTING]
 
     return base
 

--- a/tests/devices/traits/a01/test_device_feature.py
+++ b/tests/devices/traits/a01/test_device_feature.py
@@ -1,0 +1,41 @@
+"""Tests for A01 (Zeo) per-model feature gating."""
+
+import pytest
+
+from roborock.devices.traits.a01.device_feature import build_force_load_dp_list, supports_default_setting
+from roborock.roborock_message import RoborockZeoProtocol
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("roborock.wm.a63", False),  # H1
+        ("roborock.wm.a102", True),  # H1 Overseas
+        ("roborock.wm.a90", True),  # H1 Lite
+        (None, True),  # unknown model: assume supported
+    ],
+)
+def test_supports_default_setting(model: str | None, expected: bool) -> None:
+    """DP 225 is unsupported on H1 (a63) only."""
+    assert supports_default_setting(model) is expected
+
+
+def test_force_load_omits_default_setting_for_h1() -> None:
+    """H1 (a63) has a softener compartment but must not be queried for DP 225."""
+    dp_list = build_force_load_dp_list("roborock.wm.a63")
+
+    assert RoborockZeoProtocol.DEFAULT_SETTING not in dp_list
+    # The remaining softener DPs are still queried.
+    assert RoborockZeoProtocol.SOFTENER_SET in dp_list
+    assert RoborockZeoProtocol.SOFTENER_TYPE in dp_list
+    assert RoborockZeoProtocol.SOFTENER_EMPTY in dp_list
+
+
+def test_force_load_keeps_default_setting_for_other_softener_models() -> None:
+    """Other softener-equipped models still query DP 225."""
+    assert RoborockZeoProtocol.DEFAULT_SETTING in build_force_load_dp_list("roborock.wm.a102")
+
+
+def test_force_load_omits_default_setting_without_softener() -> None:
+    """Models without a softener compartment never query DP 225."""
+    assert RoborockZeoProtocol.DEFAULT_SETTING not in build_force_load_dp_list("roborock.wm.a92")


### PR DESCRIPTION
Fixes #945.

### Problem

`build_force_load_dp_list()` adds the softener block — including DP 225 (`DEFAULT_SETTING`) — to every model that has a softener compartment. The Zeo H1 (`roborock.wm.a63`) has one, so it gets asked for DP 225, but the device never answers that DP.

`send_decoded_command()` only completes a query once every requested DP has arrived:

```python
if len(result) != len(query_values):
    return
```

so `finished` is never set, the wait hits `_TIMEOUT = 10.0`, and the entire force-load fails with `Command timed out after 10.0s` — discarding every DP the device *did* answer and counting a `health_manager.on_timeout()` toward an MQTT session restart. The result is an H1 with no state at all, timing out every 10 seconds.

### Fix

Gate DP 225 behind a model set and strip it in `build_force_load_dp_list()`, mirroring how DP 237 (`FEATURE_BITS`) is already handled for this same device via `_UNSUPPORTED_FEATURE_BITS`. Unknown models keep the conservative "assume supported" default used by the neighbouring helpers.

### Testing

- New `tests/devices/traits/a01/test_device_feature.py` covers `supports_default_setting()` across a63 / a102 / a90 / `None`, and asserts the force-load list drops DP 225 for the a63 while keeping the other softener DPs and still including it for other softener-equipped models.
- Full suite passes locally (973 passed).
- Verified on a real a63: the force-load completes and state loads correctly.

### Note

`roborock.wm.a102` (H1 Overseas) is the same physical machine and very likely has the same issue, but I only have an a63 to test with, so I left it out. It can be added.
