### PR TITLE
test: eliminate unnecessary timeouts and delays in test suite

### DIFF
--- a/tests/devices/rpc/test_v1_channel.py
+++ b/tests/devices/rpc/test_v1_channel.py
@@ -807,6 +807,7 @@ async def test_v1_channel_subscribe_failure_is_atomic(
     v1_channel: V1Channel,
     mock_mqtt_channel: FakeChannel,
     mock_local_channel: FakeChannel,
+    device_cache: DeviceCache,
 ) -> None:
     """A failure partway through subscribe() leaves the channel re-subscribable.
 
@@ -814,6 +815,11 @@ async def test_v1_channel_subscribe_failure_is_atomic(
     task and a partial subscription, so the next attempt could neither reuse nor
     cleanly recreate the channel.
     """
+    # Pre-populate device cache with network info so local connect is attempted immediately
+    device_cache_data = await device_cache.get()
+    device_cache_data.network_info = TEST_NETWORKING_INFO
+    await device_cache.set(device_cache_data)
+
     # Both transports down: local connect fails and the MQTT subscribe fails.
     mock_local_channel.connect.side_effect = RoborockException("local down")
     mock_mqtt_channel.subscribe.side_effect = RoborockException("mqtt down")

--- a/tests/devices/traits/b01/q10/test_status.py
+++ b/tests/devices/traits/b01/q10/test_status.py
@@ -79,10 +79,11 @@ def build_q10_message(payload: bytes) -> Q10Message:
 
 async def wait_for_attribute_value(obj: Any, attribute: str, value: Any, timeout: float = 2.0) -> None:
     """Wait for an attribute on an object to reach a specific value."""
-    for _ in range(int(timeout / 0.1)):
+    step = 0.005
+    for _ in range(int(timeout / step)):
         if getattr(obj, attribute) == value:
             return
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(step)
     pytest.fail(f"Timeout waiting for {attribute} to become {value} on {obj}")
 
 

--- a/tests/e2e/test_device_manager.py
+++ b/tests/e2e/test_device_manager.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 import syrupy
@@ -364,8 +365,9 @@ async def test_l01_device(
     for payload in local_responses:
         local_response_queue.put_nowait(payload)
 
-    # Create the device manager
-    device_manager = await device_manager_factory(TEST_USER_PARAMS)
+    # Create the device manager with short local timeout for L01 fallback test
+    with patch("roborock.devices.transport.local_channel._TIMEOUT", 0.05):
+        device_manager = await device_manager_factory(TEST_USER_PARAMS)
 
     # The mocked Home Data API returns a single v1 device
     devices = await device_manager.get_devices()

--- a/tests/e2e/test_local_session.py
+++ b/tests/e2e/test_local_session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncGenerator
+from unittest.mock import patch
 
 import pytest
 import syrupy
@@ -167,7 +168,8 @@ async def test_l01_session(
         )
     )
 
-    await local_channel.connect()
+    with patch("roborock.devices.transport.local_channel._TIMEOUT", 0.05):
+        await local_channel.connect()
 
     assert local_channel.is_connected
 


### PR DESCRIPTION
## Description

This PR eliminates unnecessary artificial timeouts and delays in the test suite, reducing overall test runtime from **48.76s** down to **27.12s** (~44% runtime reduction) without altering test parallelism or touching A01 traits.

### Summary of Changes

1. **Fix 10.01s MQTT RPC timeout in `test_v1_channel_subscribe_failure_is_atomic`** ([tests/devices/rpc/test_v1_channel.py](file:///home/vscode/.gemini/antigravity/worktrees/python-roborock/review_test_speed/tests/devices/rpc/test_v1_channel.py))
   - During `v1_channel.subscribe()`, `_local_connect()` checks the device cache for network info. Because the cache was empty, it attempted to query network info via MQTT `GET_NETWORK_INFO`. With no response queued, it blocked for the full 10.0s RPC timeout before raising `RoborockTimeout`.
   - Pre-populating `device_cache` with `TEST_NETWORKING_INFO` allows `_local_connect()` to immediately invoke `mock_local_channel.connect()`, triggering the intended local connection failure in <0.01s.

2. **Shorten handshake timeout in `test_l01_device` and `test_l01_session`** ([tests/e2e/test_device_manager.py](file:///home/vscode/.gemini/antigravity/worktrees/python-roborock/review_test_speed/tests/e2e/test_device_manager.py), [tests/e2e/test_local_session.py](file:///home/vscode/.gemini/antigravity/worktrees/python-roborock/review_test_speed/tests/e2e/test_local_session.py))
   - When connecting locally to an L01 device, `LocalChannel` attempts V1 first, which is rejected with dummy bytes (`b'\x00'`). Because this packet cannot be decoded as a `HELLO_RESPONSE`, the channel previously waited for the full `_TIMEOUT = 5.0s` before falling back to L01 (a known delay documented in the test docstring).
   - Patching `_TIMEOUT` to 50ms during this protocol fallback test eliminates ~10s of idle waiting across the two tests.

3. **Reduce polling sleep in `wait_for_attribute_value`** ([tests/devices/traits/b01/q10/test_status.py](file:///home/vscode/.gemini/antigravity/worktrees/python-roborock/review_test_speed/tests/devices/traits/b01/q10/test_status.py))
   - Reduced the polling step from 100ms (`0.1s`) to 5ms (`0.005s`), shaving off ~0.3s across the three streaming/refresh status trait tests.

---

### Future Work: A01 Device & Simulator Timeouts (~20s)
We identified two additional 10s timeouts in A01 testing:
- `tests/e2e/test_device_manager.py::test_a01_device[home_data0]` (~10s)
- `tests/testing/test_a01_simulator.py::test_a01_device_manager_integration` (~10s)

During `device.start_connect()`, `ZeoApi.start()` runs `_force_load()` querying 35 datapoints via `build_force_load_dp_list`. Because `a01_channel` requires all queried keys to match before resolving, incomplete mock or simulator responses cause `a01_channel` to hit its 10s timeout before continuing. These are intentionally deferred to a separate PR as they relate to A01 trait design and production behavior.

### Test Results
- All 987 tests pass.
- Ruff and formatting checks pass cleanly.